### PR TITLE
Fix Kimi weekly and 5-hour rate-window mapping

### DIFF
--- a/contents/ui/OverviewPage.qml
+++ b/contents/ui/OverviewPage.qml
@@ -35,8 +35,10 @@ ColumnLayout {
                 return x ? Object.assign({}, x) : null
             }
             readonly property var usage: d && d.entry && d.entry.usage ? d.entry.usage : null
-            readonly property var primaryWin: usage ? Catalog.usableWindow(usage.primary) : null
-            readonly property var secondaryWin: usage ? Catalog.usableWindow(usage.secondary) : null
+            // Rate-window slots are provider implementation details. Kimi returns
+            // the weekly cap in primary and the five-hour cap in secondary.
+            readonly property var primaryWin: usage ? Catalog.windowFor(usage, providerId, 300) : null
+            readonly property var secondaryWin: usage ? Catalog.windowFor(usage, providerId, 10080) : null
 
             Layout.fillWidth: true
             implicitHeight: rowContent.implicitHeight + Kirigami.Units.smallSpacing * 2

--- a/contents/ui/ProviderCard.qml
+++ b/contents/ui/ProviderCard.qml
@@ -31,16 +31,32 @@ ColumnLayout {
         var out = []
         if (!usage)
             return out
-        var pw = Catalog.usableWindow(usage.primary)
-        var sw = Catalog.usableWindow(usage.secondary)
-        var tw = Catalog.usableWindow(usage.tertiary)
-        if (pw)
-            out.push({ title: Catalog.windowTitle(pw.windowMinutes, "Session"), win: pw, pace: null })
-        if (sw)
-            out.push({ title: Catalog.windowTitle(sw.windowMinutes, "Weekly"), win: sw,
-                       pace: entry.pace && entry.pace.secondary ? entry.pace.secondary : null })
-        if (tw)
-            out.push({ title: Catalog.windowTitle(tw.windowMinutes, "Monthly"), win: tw, pace: null })
+        var slots = ["primary", "secondary", "tertiary"]
+        for (var i = 0; i < slots.length; i++) {
+            var slot = slots[i]
+            var w = Catalog.usableWindow(usage[slot])
+            if (!w)
+                continue
+            var minutes = Catalog.effectiveWindowMinutes(w, providerId, slot)
+            var fallback = slot === "primary" ? "Session"
+                         : slot === "secondary" ? "Weekly" : "Monthly"
+            out.push({
+                title: Catalog.windowTitle(minutes, fallback),
+                win: w,
+                minutes: minutes,
+                pace: minutes === 10080 && entry.pace && entry.pace.secondary
+                      ? entry.pace.secondary : null
+            })
+        }
+        // Kimi's transport slots are inverted. Keep legacy ordering for every
+        // other provider, especially those without window duration metadata.
+        if (providerId === "kimi") {
+            out.sort(function (a, b) {
+                var am = a.minutes > 0 ? a.minutes : Number.MAX_VALUE
+                var bm = b.minutes > 0 ? b.minutes : Number.MAX_VALUE
+                return am - bm
+            })
+        }
         if (usage.extraRateWindows) {
             for (var i = 0; i < usage.extraRateWindows.length; i++) {
                 var ew = usage.extraRateWindows[i]
@@ -171,7 +187,8 @@ ColumnLayout {
 
             PlasmaComponents3.Label {
                 visible: text !== ""
-                text: Catalog.paceLine(section.modelData.pace)
+                text: Catalog.paceLine(section.modelData.pace, section.modelData.win,
+                                       section.modelData.minutes, plasmoidRoot.nowMs, providerId)
                 opacity: 0.55
                 font: Kirigami.Theme.smallFont
                 Layout.fillWidth: true

--- a/contents/ui/code/catalog.js
+++ b/contents/ui/code/catalog.js
@@ -152,26 +152,98 @@ function usableWindow(w) {
     return w
 }
 
+// The Kimi endpoint omits `windowMinutes` for its weekly window. Treat slots
+// as transport fields rather than as semantic names: providers may return
+// rate windows in either order.
+function effectiveWindowMinutes(w, providerId, slot) {
+    if (!w) return 0
+    var minutes = Number(w.windowMinutes)
+    if (isFinite(minutes) && minutes > 0) return minutes
+
+    var description = String(w.resetDescription || "").toLowerCase()
+    if (/per\s*5\s*hours?|5\s*h(?:ours?)?/.test(description)) return 300
+    if (providerId === "kimi" && slot === "primary") return 10080
+    return 0
+}
+
+function windowFor(usage, providerId, wantedMinutes) {
+    if (!usage) return null
+    var slots = ["primary", "secondary", "tertiary"]
+    for (var i = 0; i < slots.length; i++) {
+        var w = usableWindow(usage[slots[i]])
+        if (w && effectiveWindowMinutes(w, providerId, slots[i]) === wantedMinutes)
+            return w
+    }
+    // Preserve the legacy slot contract for other providers whose API payloads
+    // do not include a window duration. Kimi is the only known inverted pair.
+    if (providerId !== "kimi") {
+        if (wantedMinutes === 300) return usableWindow(usage.primary)
+        if (wantedMinutes === 10080) return usableWindow(usage.secondary)
+    }
+    return null
+}
+
 function windowUsageKnown(w) {
     return w && w.usageKnown !== false && w.usedPercent !== undefined
 }
 
+function normalizedPercent(value) {
+    var n = Number(value)
+    if (!isFinite(n)) return 0
+    return Math.max(0, Math.min(100, Math.round(n)))
+}
+
 function windowUsedText(w) {
-    return windowUsageKnown(w) ? String(w.usedPercent) : "–"
+    return windowUsageKnown(w) ? String(normalizedPercent(w.usedPercent)) : "–"
 }
 
 function windowBarPercent(w) {
-    return windowUsageKnown(w) ? w.usedPercent : 0
+    return windowUsageKnown(w) ? normalizedPercent(w.usedPercent) : 0
 }
 
-// Menu pace line, e.g. "Pace: 24% in reserve · Lasts until reset"
-// built from the CLI's pace.summary ("24% in reserve | Expected 51% used | Lasts until reset")
-function paceLine(pace) {
-    if (!pace || !pace.summary) return ""
-    var parts = pace.summary.split("|").map(function (p) { return p.trim() })
-    var keep = parts.filter(function (p) { return p.indexOf("Expected") !== 0 })
-    if (keep.length === 0) return ""
-    return "Pace: " + keep.join(" · ")
+// Menu pace line, matching CodexBarCore UsagePace / UsagePaceText. Kimi does
+// not return the CLI's pre-computed `pace` payload, so reproduce that logic
+// from the weekly window without rounding the values used in the projection.
+function paceLine(pace, win, windowMinutes, nowMs, providerId) {
+    if (pace && pace.summary) {
+        var parts = pace.summary.split("|").map(function (p) { return p.trim() })
+        var keep = parts.filter(function (p) { return p.indexOf("Expected") !== 0 })
+        if (keep.length > 0) return "Pace: " + keep.join(" · ")
+    }
+    if (windowMinutes !== 10080 || !windowUsageKnown(win) || !win.resetsAt)
+        return ""
+
+    var resetMs = Date.parse(win.resetsAt)
+    var durationMs = windowMinutes * 60 * 1000
+    var timeUntilReset = resetMs - nowMs
+    if (isNaN(resetMs) || timeUntilReset <= 0 || timeUntilReset > durationMs)
+        return ""
+
+    var elapsed = Math.max(0, Math.min(durationMs, durationMs - timeUntilReset))
+    var actual = Math.max(0, Math.min(100, Number(win.usedPercent)))
+    if (elapsed === 0 && actual > 0)
+        return ""
+    var expected = (elapsed / durationMs) * 100
+    // CodexBarCore hides pace until enough of the weekly window has elapsed.
+    if (expected < 3 && actual < 100)
+        return ""
+    var delta = actual - expected
+    var deltaDisplay = Math.round(Math.abs(delta))
+    var left = (Math.abs(delta) <= 2 || deltaDisplay === 0)
+        ? "On pace"
+        : deltaDisplay + "% " + (delta > 0 ? "in deficit" : "in reserve")
+
+    var right = ""
+    if (actual >= 100) {
+        right = "Runs out now"
+    } else if (elapsed > 0 && actual > 0) {
+        var etaMs = (100 - actual) / (actual / elapsed)
+        right = etaMs >= timeUntilReset ? "Lasts until reset"
+                                         : "Runs out in " + duration(Math.ceil(etaMs / 1000))
+    } else if (elapsed > 0 && actual === 0) {
+        right = "Lasts until reset"
+    }
+    return "Pace: " + left + (right !== "" ? " · " + right : "")
 }
 
 // Section title for a rate window ("Session", "Weekly", "Monthly", or a custom title)

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -51,10 +51,10 @@ PlasmoidItem {
             if (d && d.entry && d.entry.usage) {
                 var u = d.entry.usage
                 var parts = []
-                var pw = Catalog.usableWindow(u.primary)
-                var sw = Catalog.usableWindow(u.secondary)
-                if (Catalog.windowUsageKnown(pw)) parts.push("Session " + (100 - pw.usedPercent) + "% left")
-                if (Catalog.windowUsageKnown(sw)) parts.push("Weekly " + (100 - sw.usedPercent) + "% left")
+                var pw = Catalog.windowFor(u, p, 300)
+                var sw = Catalog.windowFor(u, p, 10080)
+                if (Catalog.windowUsageKnown(pw)) parts.push("Session " + (100 - Catalog.normalizedPercent(pw.usedPercent)) + "% left")
+                if (Catalog.windowUsageKnown(sw)) parts.push("Weekly " + (100 - Catalog.normalizedPercent(sw.usedPercent)) + "% left")
                 lines.push(m.name + " — " + (parts.length > 0 ? parts.join(" · ") : "no data"))
             } else if (d && d.loading) {
                 lines.push(m.name + " — refreshing…")
@@ -178,10 +178,10 @@ PlasmoidItem {
         if (!d || !d.entry || !d.entry.usage)
             return -1
         var u = d.entry.usage
-        var pw = Catalog.usableWindow(u.primary)
-        var sw = Catalog.usableWindow(u.secondary)
-        var rp = Catalog.windowUsageKnown(pw) ? 100 - pw.usedPercent : -1
-        var rs = Catalog.windowUsageKnown(sw) ? 100 - sw.usedPercent : -1
+        var pw = Catalog.windowFor(u, p, 300)
+        var sw = Catalog.windowFor(u, p, 10080)
+        var rp = Catalog.windowUsageKnown(pw) ? 100 - Catalog.normalizedPercent(pw.usedPercent) : -1
+        var rs = Catalog.windowUsageKnown(sw) ? 100 - Catalog.normalizedPercent(sw.usedPercent) : -1
         if (source === "weekly")
             return rs >= 0 ? rs : rp
         if (source === "lowest") {


### PR DESCRIPTION
## Summary

This fixes the Kimi rate-limit windows being displayed in the wrong places and restores a useful weekly pace line when the CLI does not provide one.

- Resolve the session and weekly windows by duration rather than assuming that `primary` and `secondary` are semantic positions.
- Handle Kimi's current payload shape: the weekly window is in `primary` without `windowMinutes`, while the 5-hour window is in `secondary`.
- Keep the previous positional fallback for other providers that do not expose duration metadata.
- Use the corrected mapping in the Overview, provider cards, compact-bar tooltip, and panel percentage source.
- Normalize displayed percentages to avoid floating-point artifacts such as `28.999999999999996`.
- Derive the weekly pace headline for providers without a CLI `pace` object, following CodexBarCore's display behavior (including its early-window visibility threshold).

## Reproduction

With `codexbar usage --provider kimi --json`, Kimi currently reports:

- `usage.primary`: weekly limit, with no `windowMinutes`;
- `usage.secondary`: 5-hour limit, with `windowMinutes: 300`.

The existing slot-based rendering therefore labeled those two windows incorrectly in Overview and could also select the wrong value for the panel/tooltip.

## Validation

- Verified the mapping against the live Kimi CLI payload.
- Exercised Kimi session/weekly selection, non-Kimi legacy fallback, percentage rounding, pace projection, and the upstream early-window pace visibility rule with a Node assertion script.
- Parsed the changed QML files with `qmlformat`.
- Ran `git diff --check`.

Thank you for maintaining this Plasma port.