### PR TITLE
claude: add multi-account adapter view

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,11 @@ operations:
 
 The widget validates schema version 1 and retains only account slot, optional
 `alias`/`organizationName`/email display identity, active state, the optional
-`disabled` rotation flag, usage status, the 5-hour/7-day usage windows, and
-optional model-scoped weekly windows. When present, identity is displayed as
-`alias`, then `organizationName`, then email.
+`disabled` rotation flag, usage status, the 5-hour/7-day usage windows,
+optional model-scoped weekly windows, and optional pay-as-you-go `spend`
+(`used`/`limit`/`pct`/`currency`), which only the adapter can report per
+account. When present, identity is displayed as `alias`, then
+`organizationName`, then email.
 Each account row may optionally report `usageFetchedAt` (ISO 8601 timestamp) or
 `usageAgeSeconds` (non-negative seconds); when present, the card timestamp and
 staleness reflect measurement time rather than poll time, so cached usage is
@@ -82,6 +84,12 @@ windows go through the same strict projection, are timestamped from the
 last-good measurement, and are labelled `last known` instead of being shown as
 current. It does not read credentials or profile IDs.
 
+Weekly windows (`sevenDay` and model-scoped entries) may additively report the
+adapter's own pace verdict as `expectedPct`/`aheadOfPace`; when present it is
+preferred over the pace line the widget otherwise reconstructs locally. The
+`projectedExhaustionAt`/`willLastToReset` projections are deliberately not
+read — claude-swap keeps that linear extrapolation out of its human surfaces.
+
 Account switches are serialized and only run after an explicit click. The
 switch action is offered for the `ok`, `api_key`, `unavailable`,
 `token_expired`, and `foreign_credential` statuses — the last two because an
@@ -90,7 +98,10 @@ belonging to another account. `keychain_unavailable`, `no_credentials`, and
 `relogin_required` instead report what has to be fixed outside the widget. A
 `disabled` slot is only held out of the adapter's automatic rotation and stays
 a valid explicit target, so the card labels it `Not in rotation` without
-withdrawing the switch action.
+withdrawing the switch action. Any `warnings` the switch result carries are
+shown afterwards, including on a successful switch: in `--json` mode adapters
+report them in the payload rather than on stderr, so this is the only place
+they can reach you.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ section is enabled, automatic cost scans are serialized and run no more than
 once per provider per hour. Use **Refresh cost history** on a Codex or Claude
 provider page when an immediate scan is required.
 
-### Optional Claude multi-account adapter
+## Optional Claude multi-account adapter
 
 Enable **Show all accounts from a schema-v1 adapter** and set the adapter
 executable path. Compatible adapters must implement only these CodexBar

--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ a faithful re-creation of [CodexBar](https://github.com/steipete/CodexBar)
   because large local histories can be resource-intensive.
 - **Actions:** Refresh, explicit cost-history refresh, Usage Dashboard, Status
   Page, Settings, About.
+- **Optional Claude multi-account view:** stacked 5-hour and 7-day cards,
+  active-account state, and explicit account switching through a compatible
+  schema-v1 `claude-swap` adapter.
 - **Settings:** refresh interval, any of the 58 providers the CLI supports,
   panel percentage (session/weekly/lowest, remaining/used), plain bars,
-  cost/status toggles, custom CLI path.
+  cost/status toggles, custom CLI path, Claude account adapter.
 
 ## Requirements
 
@@ -54,6 +57,34 @@ section is enabled, automatic cost scans are serialized and run no more than
 once per provider per hour. Use **Refresh cost history** on a Codex or Claude
 provider page when an immediate scan is required.
 
+### Optional Claude multi-account adapter
+
+Enable **Show all accounts from a schema-v1 adapter** and set the adapter
+executable path. Compatible adapters must implement only these CodexBar
+operations:
+
+```text
+--list --json
+--switch-to <positive-slot> --json
+```
+
+The widget validates schema version 1 and retains only account slot, optional
+`alias`/`organizationName`/email display identity, active state, usage status,
+the 5-hour/7-day usage windows, and optional model-scoped weekly windows. When
+present, identity is displayed as `alias`, then `organizationName`, then email.
+It does not read credentials or profile IDs.
+Account switches are serialized and only run after an explicit click.
+
+Examples:
+
+- Install [`claude-swap`](https://github.com/realiti4/claude-swap) and leave
+  the path empty to use `cswap` from `PATH`.
+- For another compatible adapter, set its absolute path or a path beginning
+  with `~/`.
+
+The CodexBar CLI remains required: normal Claude usage continues to power the
+panel icon, overview, cost, provider status, and fallback card.
+
 ## Install
 
 ```bash
@@ -74,8 +105,8 @@ systemctl --user restart plasma-plasmashell.service   # reload cached QML
 ## Not ported (macOS-only upstream features)
 
 Menu bar animations (blink/wiggle), WidgetKit widgets, notifications,
-cost-history charts, the multi-account UI and the "Add Account" flow —
-logins are handled by the provider CLIs themselves.
+cost-history charts, and the "Add Account" flow — logins are handled by the
+provider CLIs themselves.
 
 ## Credits & license
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ The widget validates schema version 1 and retains only account slot, optional
 optional model-scoped weekly windows, and optional pay-as-you-go `spend`
 (`used`/`limit`/`pct`/`currency`), which only the adapter can report per
 account. When present, identity is displayed as `alias`, then
-`organizationName`, then email.
+`organizationName`, then email. The optional `isOrganization` boolean (set from
+whether the account has an organization, without exposing its uuid) only adds
+a `Personal`/`Organization` tag when `organizationName` is empty — an org
+account with an unresolved name is still told apart from a personal one.
 Each account row may optionally report `usageFetchedAt` (ISO 8601 timestamp) or
 `usageAgeSeconds` (non-negative seconds); when present, the card timestamp and
 staleness reflect measurement time rather than poll time, so cached usage is

--- a/README.md
+++ b/README.md
@@ -74,10 +74,19 @@ the 5-hour/7-day usage windows, and optional model-scoped weekly windows. When
 present, identity is displayed as `alias`, then `organizationName`, then email.
 Each account row may optionally report `usageFetchedAt` (ISO 8601 timestamp) or
 `usageAgeSeconds` (non-negative seconds); when present, the card timestamp and
-staleness reflect measurement time rather than poll time, so cached or
-last-known usage is shown as stale instead of fresh. It does not read
-credentials or profile IDs.
-Account switches are serialized and only run after an explicit click.
+staleness reflect measurement time rather than poll time, so cached usage is
+shown as stale instead of fresh. When a live fetch fails, a row may instead
+carry `lastGoodUsage` with `lastGoodFetchedAt`/`lastGoodAgeSeconds`; those
+windows go through the same strict projection, are timestamped from the
+last-good measurement, and are labelled `last known` instead of being shown as
+current. It does not read credentials or profile IDs.
+
+Account switches are serialized and only run after an explicit click. The
+switch action is offered for the `ok`, `api_key`, `unavailable`,
+`token_expired`, and `foreign_credential` statuses — the last two because an
+explicit switch is what refreshes an expired token or replaces a credential
+belonging to another account. `keychain_unavailable`, `no_credentials`, and
+`relogin_required` instead report what has to be fixed outside the widget.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ operations:
 ```
 
 The widget validates schema version 1 and retains only account slot, optional
-`alias`/`organizationName`/email display identity, active state, usage status,
-the 5-hour/7-day usage windows, and optional model-scoped weekly windows. When
-present, identity is displayed as `alias`, then `organizationName`, then email.
+`alias`/`organizationName`/email display identity, active state, the optional
+`disabled` rotation flag, usage status, the 5-hour/7-day usage windows, and
+optional model-scoped weekly windows. When present, identity is displayed as
+`alias`, then `organizationName`, then email.
 Each account row may optionally report `usageFetchedAt` (ISO 8601 timestamp) or
 `usageAgeSeconds` (non-negative seconds); when present, the card timestamp and
 staleness reflect measurement time rather than poll time, so cached usage is
@@ -86,7 +87,10 @@ switch action is offered for the `ok`, `api_key`, `unavailable`,
 `token_expired`, and `foreign_credential` statuses — the last two because an
 explicit switch is what refreshes an expired token or replaces a credential
 belonging to another account. `keychain_unavailable`, `no_credentials`, and
-`relogin_required` instead report what has to be fixed outside the widget.
+`relogin_required` instead report what has to be fixed outside the widget. A
+`disabled` slot is only held out of the adapter's automatic rotation and stays
+a valid explicit target, so the card labels it `Not in rotation` without
+withdrawing the switch action.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ The widget validates schema version 1 and retains only account slot, optional
 `alias`/`organizationName`/email display identity, active state, usage status,
 the 5-hour/7-day usage windows, and optional model-scoped weekly windows. When
 present, identity is displayed as `alias`, then `organizationName`, then email.
-It does not read credentials or profile IDs.
+Each account row may optionally report `usageFetchedAt` (ISO 8601 timestamp) or
+`usageAgeSeconds` (non-negative seconds); when present, the card timestamp and
+staleness reflect measurement time rather than poll time, so cached or
+last-known usage is shown as stale instead of fresh. It does not read
+credentials or profile IDs.
 Account switches are serialized and only run after an explicit click.
 
 Examples:

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -38,5 +38,11 @@
         <entry name="cliPath" type="String">
             <default></default>
         </entry>
+        <entry name="enableClaudeAccounts" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="claudeAdapterPath" type="String">
+            <default></default>
+        </entry>
     </group>
 </kcfg>

--- a/contents/ui/ClaudeAccountCard.qml
+++ b/contents/ui/ClaudeAccountCard.qml
@@ -90,6 +90,16 @@ ColumnLayout {
             elide: Text.ElideRight
         }
 
+        // Held out of the adapter's automatic rotation. Naming the effect
+        // rather than the `disabled` flag keeps this from reading as a broken
+        // or unusable account — the slot still works and stays switchable.
+        PlasmaComponents3.Label {
+            visible: card.account && card.account.disabled === true
+            text: i18n("Not in rotation")
+            color: Kirigami.Theme.neutralTextColor
+            font: Kirigami.Theme.smallFont
+        }
+
         PlasmaComponents3.Label {
             visible: card.account && card.account.active
             text: i18n("Active")

--- a/contents/ui/ClaudeAccountCard.qml
+++ b/contents/ui/ClaudeAccountCard.qml
@@ -65,6 +65,16 @@ ColumnLayout {
 
         Item { Layout.fillWidth: true }
 
+        // Only appears when organizationName is empty, so this never doubles
+        // up with an org name already shown by displayLabel.
+        PlasmaComponents3.Label {
+            readonly property string tag: ClaudeAccounts.organizationTag(card.account)
+            visible: tag !== ""
+            text: tag
+            opacity: 0.5
+            font: Kirigami.Theme.smallFont
+        }
+
         PlasmaComponents3.Label {
             text: card.account ? card.account.displayLabel : ""
             opacity: 0.65

--- a/contents/ui/ClaudeAccountCard.qml
+++ b/contents/ui/ClaudeAccountCard.qml
@@ -26,6 +26,15 @@ ColumnLayout {
 
     spacing: Kirigami.Units.smallSpacing
 
+    // Catalog.money renders the widget's usual "$ 1.20". An adapter reporting
+    // any other currency gets its code appended rather than a wrong symbol.
+    function moneyText(value, currency) {
+        if (typeof value !== "number" || !isFinite(value))
+            return ""
+        return (currency === "" || currency === "USD")
+            ? Catalog.money(value) : value.toFixed(2) + " " + currency
+    }
+
     function sections() {
         plasmoidRoot.rev
         var out = []
@@ -182,13 +191,20 @@ ColumnLayout {
 
             PlasmaComponents3.Label {
                 visible: text !== ""
-                // Pace weighs used percent against elapsed window time, so a
+                // Prefer the adapter's own pace verdict; only fall back to the
+                // local reconstruction when it reports none. Either way, pace
+                // weighs used percent against elapsed window time, so a
                 // last-known measurement would be scored against the wrong
                 // clock and read as behind pace.
-                text: card.lastKnownUsage ? ""
-                                          : Catalog.paceLine(null, section.modelData.win,
-                                                             section.modelData.minutes,
-                                                             card.plasmoidRoot.nowMs, "claude")
+                text: {
+                    if (card.lastKnownUsage)
+                        return ""
+                    var reported = ClaudeAccounts.paceText(section.modelData.win)
+                    return reported !== "" ? reported
+                                           : Catalog.paceLine(null, section.modelData.win,
+                                                              section.modelData.minutes,
+                                                              card.plasmoidRoot.nowMs, "claude")
+                }
                 opacity: 0.55
                 font: Kirigami.Theme.smallFont
                 Layout.fillWidth: true
@@ -197,5 +213,51 @@ ColumnLayout {
 
             Item { Layout.preferredHeight: Kirigami.Units.smallSpacing }
         }
+    }
+
+    // Pay-as-you-go spend, which only the adapter can report per account: the
+    // CodexBar CLI sees the cost of whichever account is currently active.
+    ColumnLayout {
+        id: spendSection
+        readonly property var spend: card.hasUsage && card.account.spend ? card.account.spend : null
+        visible: spend !== null
+        Layout.fillWidth: true
+        spacing: Math.round(Kirigami.Units.smallSpacing * 0.8)
+
+        PlasmaComponents3.Label {
+            text: i18n("Spend")
+            font.weight: Font.DemiBold
+            font.pointSize: Kirigami.Theme.defaultFont.pointSize * 1.05
+        }
+
+        UsageBar {
+            Layout.fillWidth: true
+            percent: Catalog.windowBarPercent(spendSection.spend)
+            fillColor: card.brandColor
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            PlasmaComponents3.Label {
+                text: spendSection.spend
+                      ? i18n("%1 of %2",
+                             card.moneyText(spendSection.spend.used, spendSection.spend.currency),
+                             card.moneyText(spendSection.spend.limit, spendSection.spend.currency))
+                      : ""
+                opacity: 0.75
+                font: Kirigami.Theme.smallFont
+                Layout.fillWidth: true
+                elide: Text.ElideRight
+            }
+
+            PlasmaComponents3.Label {
+                text: Catalog.resetText(spendSection.spend, card.plasmoidRoot.nowMs)
+                opacity: 0.6
+                font: Kirigami.Theme.smallFont
+            }
+        }
+
+        Item { Layout.preferredHeight: Kirigami.Units.smallSpacing }
     }
 }

--- a/contents/ui/ClaudeAccountCard.qml
+++ b/contents/ui/ClaudeAccountCard.qml
@@ -18,17 +18,24 @@ ColumnLayout {
     readonly property string accountError: ClaudeAccounts.statusError(account)
     readonly property bool switching: plasmoidRoot.claudeSwitchInFlight
                                       && plasmoidRoot.claudeSwitchingSlot === account.number
+    // The adapter serves last-known windows once a live fetch fails. They are
+    // display-only, so they are drawn but never presented as current.
+    readonly property bool lastKnownUsage: !!account && account.usageIsLastGood === true
+    readonly property bool hasUsage: !!account
+                                     && (account.usageStatus === "ok" || lastKnownUsage)
 
     spacing: Kirigami.Units.smallSpacing
 
     function sections() {
         plasmoidRoot.rev
         var out = []
-        if (account && account.usageStatus === "ok" && account.fiveHour)
+        if (!hasUsage)
+            return out
+        if (account.fiveHour)
             out.push({ title: "Session", win: account.fiveHour, minutes: 300 })
-        if (account && account.usageStatus === "ok" && account.sevenDay)
+        if (account.sevenDay)
             out.push({ title: "Weekly", win: account.sevenDay, minutes: 10080 })
-        if (account && account.usageStatus === "ok" && account.scoped) {
+        if (account.scoped) {
             for (var i = 0; i < account.scoped.length; i++) {
                 var scoped = account.scoped[i]
                 out.push({ title: scoped.name, win: scoped, minutes: 10080 })
@@ -72,6 +79,8 @@ ColumnLayout {
                     return ""
                 var updated = Catalog.updatedText(new Date(measuredAt).toISOString(),
                                                   card.plasmoidRoot.nowMs)
+                if (card.lastKnownUsage)
+                    return updated + i18n(" · last known")
                 return card.plasmoidRoot.isClaudeAccountStale(card.account)
                     ? updated + i18n(" · stale") : updated
             }
@@ -111,6 +120,15 @@ ColumnLayout {
     Item {
         visible: card.sections().length > 0
         Layout.preferredHeight: Kirigami.Units.smallSpacing
+    }
+
+    PlasmaComponents3.Label {
+        Layout.fillWidth: true
+        visible: card.lastKnownUsage && card.sections().length > 0
+        text: i18n("Last known usage — not current")
+        opacity: 0.7
+        font: Kirigami.Theme.smallFont
+        wrapMode: Text.WordWrap
     }
 
     Repeater {
@@ -154,9 +172,13 @@ ColumnLayout {
 
             PlasmaComponents3.Label {
                 visible: text !== ""
-                text: Catalog.paceLine(null, section.modelData.win,
-                                       section.modelData.minutes,
-                                       card.plasmoidRoot.nowMs, "claude")
+                // Pace weighs used percent against elapsed window time, so a
+                // last-known measurement would be scored against the wrong
+                // clock and read as behind pace.
+                text: card.lastKnownUsage ? ""
+                                          : Catalog.paceLine(null, section.modelData.win,
+                                                             section.modelData.minutes,
+                                                             card.plasmoidRoot.nowMs, "claude")
                 opacity: 0.55
                 font: Kirigami.Theme.smallFont
                 Layout.fillWidth: true

--- a/contents/ui/ClaudeAccountCard.qml
+++ b/contents/ui/ClaudeAccountCard.qml
@@ -65,12 +65,14 @@ ColumnLayout {
         PlasmaComponents3.Label {
             text: {
                 card.plasmoidRoot.rev
-                var fetchedAt = card.plasmoidRoot.claudeAccountData.fetchedAt
-                if (!fetchedAt)
+                var measuredAt = (card.account && typeof card.account.usageMeasuredAt === "number")
+                    ? card.account.usageMeasuredAt
+                    : card.plasmoidRoot.claudeAccountData.fetchedAt
+                if (!measuredAt)
                     return ""
-                var updated = Catalog.updatedText(new Date(fetchedAt).toISOString(),
+                var updated = Catalog.updatedText(new Date(measuredAt).toISOString(),
                                                   card.plasmoidRoot.nowMs)
-                return card.plasmoidRoot.isClaudeAccountDataStale()
+                return card.plasmoidRoot.isClaudeAccountStale(card.account)
                     ? updated + i18n(" · stale") : updated
             }
             opacity: 0.6

--- a/contents/ui/ClaudeAccountCard.qml
+++ b/contents/ui/ClaudeAccountCard.qml
@@ -1,0 +1,167 @@
+import QtQuick
+import QtQuick.Controls as QQC2
+import QtQuick.Layouts
+import org.kde.plasma.components as PlasmaComponents3
+import org.kde.kirigami as Kirigami
+import "code/catalog.js" as Catalog
+import "code/claudeAccounts.js" as ClaudeAccounts
+
+// One display-only Claude account projected from the schema-v1 adapter.
+// Credential/profile identifiers never enter this component.
+ColumnLayout {
+    id: card
+
+    required property var plasmoidRoot
+    required property var account
+
+    readonly property color brandColor: Catalog.meta("claude").color
+    readonly property string accountError: ClaudeAccounts.statusError(account)
+    readonly property bool switching: plasmoidRoot.claudeSwitchInFlight
+                                      && plasmoidRoot.claudeSwitchingSlot === account.number
+
+    spacing: Kirigami.Units.smallSpacing
+
+    function sections() {
+        plasmoidRoot.rev
+        var out = []
+        if (account && account.usageStatus === "ok" && account.fiveHour)
+            out.push({ title: "Session", win: account.fiveHour, minutes: 300 })
+        if (account && account.usageStatus === "ok" && account.sevenDay)
+            out.push({ title: "Weekly", win: account.sevenDay, minutes: 10080 })
+        if (account && account.usageStatus === "ok" && account.scoped) {
+            for (var i = 0; i < account.scoped.length; i++) {
+                var scoped = account.scoped[i]
+                out.push({ title: scoped.name, win: scoped, minutes: 10080 })
+            }
+        }
+        return out
+    }
+
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: Kirigami.Units.smallSpacing
+
+        PlasmaComponents3.Label {
+            text: i18n("Claude")
+            font.weight: Font.Bold
+            font.pointSize: Kirigami.Theme.defaultFont.pointSize * 1.25
+        }
+
+        Item { Layout.fillWidth: true }
+
+        PlasmaComponents3.Label {
+            text: card.account ? card.account.displayLabel : ""
+            opacity: 0.65
+            font: Kirigami.Theme.smallFont
+            Layout.maximumWidth: parent.width * 0.62
+            elide: Text.ElideRight
+        }
+    }
+
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: Kirigami.Units.smallSpacing
+
+        PlasmaComponents3.Label {
+            text: {
+                card.plasmoidRoot.rev
+                var fetchedAt = card.plasmoidRoot.claudeAccountData.fetchedAt
+                if (!fetchedAt)
+                    return ""
+                var updated = Catalog.updatedText(new Date(fetchedAt).toISOString(),
+                                                  card.plasmoidRoot.nowMs)
+                return card.plasmoidRoot.isClaudeAccountDataStale()
+                    ? updated + i18n(" · stale") : updated
+            }
+            opacity: 0.6
+            font: Kirigami.Theme.smallFont
+            Layout.fillWidth: true
+            elide: Text.ElideRight
+        }
+
+        PlasmaComponents3.Label {
+            visible: card.account && card.account.active
+            text: i18n("Active")
+            color: Kirigami.Theme.positiveTextColor
+            font: Kirigami.Theme.smallFont
+        }
+
+        QQC2.ToolButton {
+            visible: card.account && !card.account.active
+                     && ClaudeAccounts.canActivate(card.account)
+            text: card.switching ? i18n("Switching…") : i18n("Switch account…")
+            enabled: card.plasmoidRoot.canSwitchClaudeAccount(card.account)
+            onClicked: card.plasmoidRoot.switchClaudeAccount(card.account.number)
+        }
+    }
+
+    PlasmaComponents3.Label {
+        Layout.fillWidth: true
+        visible: card.accountError !== ""
+        text: card.accountError
+        color: card.account && card.account.usageStatus === "api_key"
+               ? Kirigami.Theme.textColor : Kirigami.Theme.negativeTextColor
+        opacity: 0.85
+        font: Kirigami.Theme.smallFont
+        wrapMode: Text.WordWrap
+    }
+
+    Item {
+        visible: card.sections().length > 0
+        Layout.preferredHeight: Kirigami.Units.smallSpacing
+    }
+
+    Repeater {
+        model: card.sections()
+
+        ColumnLayout {
+            id: section
+            required property var modelData
+            Layout.fillWidth: true
+            spacing: Math.round(Kirigami.Units.smallSpacing * 0.8)
+
+            PlasmaComponents3.Label {
+                text: section.modelData.title
+                font.weight: Font.DemiBold
+                font.pointSize: Kirigami.Theme.defaultFont.pointSize * 1.05
+            }
+
+            UsageBar {
+                Layout.fillWidth: true
+                percent: Catalog.windowBarPercent(section.modelData.win)
+                fillColor: card.brandColor
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+
+                PlasmaComponents3.Label {
+                    text: Catalog.windowUsedText(section.modelData.win) + i18n("% used")
+                    opacity: 0.75
+                    font: Kirigami.Theme.smallFont
+                }
+
+                Item { Layout.fillWidth: true }
+
+                PlasmaComponents3.Label {
+                    text: Catalog.resetText(section.modelData.win, card.plasmoidRoot.nowMs)
+                    opacity: 0.6
+                    font: Kirigami.Theme.smallFont
+                }
+            }
+
+            PlasmaComponents3.Label {
+                visible: text !== ""
+                text: Catalog.paceLine(null, section.modelData.win,
+                                       section.modelData.minutes,
+                                       card.plasmoidRoot.nowMs, "claude")
+                opacity: 0.55
+                font: Kirigami.Theme.smallFont
+                Layout.fillWidth: true
+                elide: Text.ElideRight
+            }
+
+            Item { Layout.preferredHeight: Kirigami.Units.smallSpacing }
+        }
+    }
+}

--- a/contents/ui/ClaudeAccountsPage.qml
+++ b/contents/ui/ClaudeAccountsPage.qml
@@ -16,6 +16,9 @@ ColumnLayout {
     }
     readonly property var accounts: d.accounts || []
     readonly property bool showAccounts: d.valid && accounts.length > 0
+    // In --json mode the adapter reports switch warnings only in the payload,
+    // never on stderr, so this is the one place they can reach the user.
+    readonly property var switchWarnings: d.switchWarnings || []
 
     spacing: Kirigami.Units.smallSpacing
 
@@ -48,6 +51,32 @@ ColumnLayout {
         opacity: 0.9
         font: Kirigami.Theme.smallFont
         wrapMode: Text.WordWrap
+    }
+
+    PlasmaComponents3.Label {
+        Layout.fillWidth: true
+        visible: page.switchWarnings.length > 0
+        text: page.switchWarnings.length === 1
+            ? i18n("The adapter reported a warning about the last switch:")
+            : i18n("The adapter reported warnings about the last switch:")
+        color: Kirigami.Theme.neutralTextColor
+        opacity: 0.9
+        font: Kirigami.Theme.smallFont
+        wrapMode: Text.WordWrap
+    }
+
+    Repeater {
+        model: page.switchWarnings
+
+        PlasmaComponents3.Label {
+            required property var modelData
+            Layout.fillWidth: true
+            text: "• " + modelData
+            color: Kirigami.Theme.neutralTextColor
+            opacity: 0.9
+            font: Kirigami.Theme.smallFont
+            wrapMode: Text.WordWrap
+        }
     }
 
     PlasmaComponents3.Label {

--- a/contents/ui/ClaudeAccountsPage.qml
+++ b/contents/ui/ClaudeAccountsPage.qml
@@ -1,0 +1,101 @@
+import QtQuick
+import QtQuick.Layouts
+import org.kde.plasma.components as PlasmaComponents3
+import org.kde.kirigami as Kirigami
+
+// Optional stacked Claude account view. Until an adapter list has been
+// validated, retain the ordinary Claude provider card as a safe fallback.
+ColumnLayout {
+    id: page
+
+    required property var plasmoidRoot
+
+    readonly property var d: {
+        plasmoidRoot.rev
+        return Object.assign({}, plasmoidRoot.claudeAccountData)
+    }
+    readonly property var accounts: d.accounts || []
+    readonly property bool showAccounts: d.valid && accounts.length > 0
+
+    spacing: Kirigami.Units.smallSpacing
+
+    PlasmaComponents3.Label {
+        Layout.fillWidth: true
+        visible: page.d.loading
+        text: page.showAccounts ? i18n("Refreshing Claude accounts…")
+                                : i18n("Loading Claude accounts…")
+        opacity: 0.6
+        font: Kirigami.Theme.smallFont
+    }
+
+    PlasmaComponents3.Label {
+        Layout.fillWidth: true
+        visible: page.d.error && page.d.error.length > 0
+        text: page.showAccounts
+            ? i18n("Showing the last successful account update: %1", page.d.error)
+            : page.d.error
+        color: Kirigami.Theme.negativeTextColor
+        opacity: 0.9
+        font: Kirigami.Theme.smallFont
+        wrapMode: Text.WordWrap
+    }
+
+    PlasmaComponents3.Label {
+        Layout.fillWidth: true
+        visible: page.d.switchError && page.d.switchError.length > 0
+        text: i18n("Account switch failed: %1", page.d.switchError)
+        color: Kirigami.Theme.negativeTextColor
+        opacity: 0.9
+        font: Kirigami.Theme.smallFont
+        wrapMode: Text.WordWrap
+    }
+
+    PlasmaComponents3.Label {
+        Layout.fillWidth: true
+        visible: page.d.valid && page.accounts.length === 0
+        text: i18n("The Claude account adapter reported no configured accounts. Showing normal Claude usage.")
+        opacity: 0.65
+        font: Kirigami.Theme.smallFont
+        wrapMode: Text.WordWrap
+    }
+
+    Repeater {
+        model: page.showAccounts ? page.accounts : []
+
+        ColumnLayout {
+            id: accountRow
+            required property var modelData
+            required property int index
+            Layout.fillWidth: true
+            spacing: Kirigami.Units.smallSpacing
+
+            Rectangle {
+                Layout.fillWidth: true
+                visible: accountRow.index > 0
+                implicitHeight: 1
+                color: Qt.alpha(Kirigami.Theme.textColor, 0.12)
+            }
+
+            ClaudeAccountCard {
+                Layout.fillWidth: true
+                plasmoidRoot: page.plasmoidRoot
+                account: accountRow.modelData
+            }
+        }
+    }
+
+    ProviderCard {
+        visible: page.showAccounts
+        Layout.fillWidth: true
+        plasmoidRoot: page.plasmoidRoot
+        providerId: "claude"
+        extrasOnly: true
+    }
+
+    ProviderCard {
+        visible: !page.showAccounts
+        Layout.fillWidth: true
+        plasmoidRoot: page.plasmoidRoot
+        providerId: "claude"
+    }
+}

--- a/contents/ui/FullView.qml
+++ b/contents/ui/FullView.qml
@@ -202,10 +202,19 @@ Item {
                 ProviderCard {
                     required property string modelData
                     visible: fullRoot.currentTab === modelData
+                             && !(modelData === "claude"
+                                  && fullRoot.plasmoidRoot.claudeAccountsEnabled)
                     Layout.fillWidth: true
                     plasmoidRoot: fullRoot.plasmoidRoot
                     providerId: modelData
                 }
+            }
+
+            ClaudeAccountsPage {
+                visible: fullRoot.currentTab === "claude"
+                         && fullRoot.plasmoidRoot.claudeAccountsEnabled
+                Layout.fillWidth: true
+                plasmoidRoot: fullRoot.plasmoidRoot
             }
 
             AboutPage {

--- a/contents/ui/ProviderCard.qml
+++ b/contents/ui/ProviderCard.qml
@@ -12,6 +12,7 @@ ColumnLayout {
 
     required property var plasmoidRoot
     required property string providerId
+    property bool extrasOnly: false
 
     readonly property var meta: Catalog.meta(providerId)
     // shallow-copy so the property change signal fires on every data revision
@@ -103,6 +104,7 @@ ColumnLayout {
 
     // ---- header ----
     RowLayout {
+        visible: !card.extrasOnly
         Layout.fillWidth: true
         spacing: Kirigami.Units.smallSpacing
 
@@ -124,7 +126,7 @@ ColumnLayout {
 
     PlasmaComponents3.Label {
         Layout.fillWidth: true
-        visible: text !== ""
+        visible: !card.extrasOnly && text !== ""
         text: {
             plasmoidRoot.rev
             if (card.d && card.d.loading)
@@ -143,11 +145,14 @@ ColumnLayout {
         wrapMode: Text.WordWrap
     }
 
-    Item { Layout.preferredHeight: Kirigami.Units.smallSpacing }
+    Item {
+        visible: !card.extrasOnly
+        Layout.preferredHeight: Kirigami.Units.smallSpacing
+    }
 
     // ---- rate window sections ----
     Repeater {
-        model: card.sections()
+        model: card.extrasOnly ? [] : card.sections()
 
         ColumnLayout {
             id: section
@@ -202,9 +207,10 @@ ColumnLayout {
     // ---- credits (Codex) ----
     ColumnLayout {
         Layout.fillWidth: true
-        visible: (card.entry && card.entry.credits && card.entry.credits.remaining !== undefined)
-                 || (card.usage && card.usage.codexResetCredits
-                     && card.usage.codexResetCredits.availableCount > 0)
+        visible: !card.extrasOnly
+                 && ((card.entry && card.entry.credits && card.entry.credits.remaining !== undefined)
+                     || (card.usage && card.usage.codexResetCredits
+                         && card.usage.codexResetCredits.availableCount > 0))
         spacing: Math.round(Kirigami.Units.smallSpacing * 0.8)
 
         Rectangle {
@@ -327,7 +333,8 @@ ColumnLayout {
     }
 
     PlasmaComponents3.Label {
-        visible: card.usage && card.usage.identity && card.usage.identity.accountEmail !== undefined
+        visible: !card.extrasOnly && card.usage && card.usage.identity
+                 && card.usage.identity.accountEmail !== undefined
         text: card.usage && card.usage.identity && card.usage.identity.accountEmail
               ? i18n("Account: %1", card.usage.identity.accountEmail) : ""
         opacity: 0.55

--- a/contents/ui/code/claudeAccounts.js
+++ b/contents/ui/code/claudeAccounts.js
@@ -236,6 +236,11 @@ function parseList(text, nowMs) {
             alias: alias,
             displayLabel: displayLabel !== "" ? displayLabel : "Account " + row.number,
             active: row.active,
+            // Additive schema-v1 flag, emitted only for slots the user held
+            // out of automatic rotation. Such a slot stays a valid explicit
+            // switch target, so this is display-only and never gates the
+            // switch action.
+            disabled: row.disabled === true,
             usageStatus: row.usageStatus,
             fiveHour: fiveHour.value,
             sevenDay: sevenDay.value,

--- a/contents/ui/code/claudeAccounts.js
+++ b/contents/ui/code/claudeAccounts.js
@@ -275,10 +275,18 @@ function parseList(text, nowMs) {
         var organizationName = optionalText(row, "organizationName")
         var alias = optionalText(row, "alias")
         var displayLabel = alias || organizationName || email
+        // Additive: claude-swap sets this from whether the account has an
+        // organization uuid, without exposing the uuid itself. organizationName
+        // already carries the org's name when known, so this only adds
+        // information when the name is absent — an org account whose name a
+        // compatible adapter could not resolve is still worth telling apart
+        // from a personal one instead of silently falling back to email.
+        var isOrganization = typeof row.isOrganization === "boolean" ? row.isOrganization : null
         var account = {
             number: row.number,
             email: email,
             organizationName: organizationName,
+            isOrganization: isOrganization,
             alias: alias,
             displayLabel: displayLabel !== "" ? displayLabel : "Account " + row.number,
             active: row.active,
@@ -413,6 +421,16 @@ function canActivate(account) {
     if (!account || account.active)
         return false
     return SWITCHABLE_STATUSES.indexOf(account.usageStatus) >= 0
+}
+
+// Only adds a tag when organizationName is empty and isOrganization was
+// reported: an org account whose name is unresolvable still shouldn't read as
+// personal, and claude-swap's own displays use exactly this org-name-or-
+// "personal" tag once the name is missing (see its _get_display_tag).
+function organizationTag(account) {
+    if (!account || account.organizationName || account.isOrganization === null)
+        return ""
+    return account.isOrganization ? "Organization" : "Personal"
 }
 
 function statusError(account) {

--- a/contents/ui/code/claudeAccounts.js
+++ b/contents/ui/code/claudeAccounts.js
@@ -1,0 +1,286 @@
+// Strict, credential-free projection of CodexBar's schema-v1 claude-swap
+// adapter. Only display-safe account fields are retained.
+.pragma library
+
+var MAX_OUTPUT_BYTES = 262144
+
+function hasOwn(object, key) {
+    return Object.prototype.hasOwnProperty.call(object, key)
+}
+
+function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function isPositiveInteger(value) {
+    return typeof value === "number" && isFinite(value)
+        && Math.floor(value) === value && value > 0
+}
+
+function optionalText(object, key) {
+    return typeof object[key] === "string" ? object[key].trim() : ""
+}
+
+function exceedsUtf8Limit(text, limit) {
+    var bytes = 0
+    for (var i = 0; i < text.length; i++) {
+        var code = text.charCodeAt(i)
+        if (code <= 0x7f) {
+            bytes += 1
+        } else if (code <= 0x7ff) {
+            bytes += 2
+        } else if (code >= 0xd800 && code <= 0xdbff
+                   && i + 1 < text.length) {
+            var next = text.charCodeAt(i + 1)
+            if (next >= 0xdc00 && next <= 0xdfff) {
+                bytes += 4
+                i++
+            } else {
+                bytes += 3
+            }
+        } else {
+            bytes += 3
+        }
+        if (bytes > limit)
+            return true
+    }
+    return false
+}
+
+function parseJson(text, operation) {
+    var output = String(text || "")
+    if (exceedsUtf8Limit(output, MAX_OUTPUT_BYTES))
+        return { ok: false, error: "The Claude account adapter output is too large." }
+    var raw = output.trim()
+    if (raw.length === 0)
+        return { ok: false, error: "The Claude account adapter returned no output." }
+    try {
+        var value = JSON.parse(raw)
+        if (!isObject(value))
+            return { ok: false, error: "The Claude account adapter returned an invalid " + operation + " object." }
+        return { ok: true, value: value }
+    } catch (e) {
+        return { ok: false, error: "The Claude account adapter returned invalid JSON." }
+    }
+}
+
+function errorEnvelope(object) {
+    if (!isObject(object.error))
+        return ""
+    var type = typeof object.error.type === "string" && object.error.type.trim() !== ""
+        ? object.error.type.trim() : "Error"
+    var message = typeof object.error.message === "string" && object.error.message.trim() !== ""
+        ? object.error.message.trim() : "unknown error"
+    return type + ": " + message
+}
+
+function schemaError(object) {
+    if (!hasOwn(object, "schemaVersion") || typeof object.schemaVersion !== "number"
+            || !isFinite(object.schemaVersion) || Math.floor(object.schemaVersion) !== object.schemaVersion)
+        return "The Claude account adapter output has no numeric schemaVersion."
+    if (object.schemaVersion !== 1)
+        return "Unsupported Claude account adapter schema version " + object.schemaVersion + "; expected version 1."
+    return ""
+}
+
+function parseWindow(raw, slot, name) {
+    if (raw === undefined || raw === null)
+        return { ok: true, value: null }
+    if (!isObject(raw))
+        return { ok: false, error: "Account " + slot + " has an invalid " + name + " usage window." }
+    if (typeof raw.pct !== "number" || !isFinite(raw.pct))
+        return { ok: false, error: "Account " + slot + " has an invalid " + name + " usage percentage." }
+
+    var resetsAt = null
+    // Some compatible schema-v1 adapters emit an explicit JSON null here.
+    if (hasOwn(raw, "resetsAt") && raw.resetsAt !== null) {
+        if (typeof raw.resetsAt !== "string" || raw.resetsAt.trim() === ""
+                || isNaN(Date.parse(raw.resetsAt)))
+            return { ok: false, error: "Account " + slot + " has an invalid " + name + " reset timestamp." }
+        resetsAt = raw.resetsAt
+    }
+    return {
+        ok: true,
+        value: {
+            usedPercent: Math.max(0, Math.min(100, raw.pct)),
+            resetsAt: resetsAt,
+            usageKnown: true
+        }
+    }
+}
+
+// usage.scoped is additive schema-v1 data. Ignore malformed rows so a future
+// model label cannot suppress otherwise valid account-wide windows.
+function parseScopedWindows(raw) {
+    if (!Array.isArray(raw))
+        return []
+    var windows = []
+    for (var i = 0; i < raw.length; i++) {
+        var row = raw[i]
+        if (!isObject(row) || typeof row.name !== "string" || row.name.trim() === ""
+                || typeof row.pct !== "number" || !isFinite(row.pct))
+            continue
+        var resetsAt = null
+        if (hasOwn(row, "resetsAt")) {
+            if (typeof row.resetsAt !== "string" || row.resetsAt.trim() === ""
+                    || isNaN(Date.parse(row.resetsAt)))
+                continue
+            resetsAt = row.resetsAt
+        }
+        windows.push({
+            name: row.name.trim(),
+            usedPercent: Math.max(0, Math.min(100, row.pct)),
+            resetsAt: resetsAt,
+            usageKnown: true
+        })
+    }
+    return windows
+}
+
+function parseList(text) {
+    var decoded = parseJson(text, "account list")
+    if (!decoded.ok)
+        return decoded
+    var object = decoded.value
+    var versionError = schemaError(object)
+    if (versionError !== "")
+        return { ok: false, error: versionError }
+    var reportedError = errorEnvelope(object)
+    if (reportedError !== "")
+        return { ok: false, error: reportedError }
+    if (!Array.isArray(object.accounts))
+        return { ok: false, error: "The Claude account adapter output has no accounts array." }
+    if (!hasOwn(object, "activeAccountNumber"))
+        return { ok: false, error: "The Claude account adapter output has no activeAccountNumber." }
+    if (object.activeAccountNumber !== null && !isPositiveInteger(object.activeAccountNumber))
+        return { ok: false, error: "The Claude account adapter returned an invalid active account slot." }
+
+    var accounts = []
+    var slots = {}
+    var activeSlots = []
+    for (var i = 0; i < object.accounts.length; i++) {
+        var row = object.accounts[i]
+        if (!isObject(row))
+            return { ok: false, error: "The Claude account adapter returned an invalid account row." }
+        if (!isPositiveInteger(row.number))
+            return { ok: false, error: "The Claude account adapter returned a non-positive account slot." }
+        if (slots[row.number] === true)
+            return { ok: false, error: "The Claude account adapter returned duplicate account slot " + row.number + "." }
+        slots[row.number] = true
+        if (typeof row.active !== "boolean")
+            return { ok: false, error: "Account " + row.number + " has no active flag." }
+        if (typeof row.usageStatus !== "string")
+            return { ok: false, error: "Account " + row.number + " has no usageStatus." }
+
+        var usage = isObject(row.usage) ? row.usage : {}
+        var fiveHour = parseWindow(usage.fiveHour, row.number, "five-hour")
+        if (!fiveHour.ok)
+            return fiveHour
+        var sevenDay = parseWindow(usage.sevenDay, row.number, "seven-day")
+        if (!sevenDay.ok)
+            return sevenDay
+
+        var email = optionalText(row, "email")
+        // These are canonical claude-swap schema-v1 identity fields. Keep
+        // malformed optional values non-fatal so older/custom adapters remain
+        // compatible while giving same-email accounts a useful label.
+        var organizationName = optionalText(row, "organizationName")
+        var alias = optionalText(row, "alias")
+        var displayLabel = alias || organizationName || email
+        var account = {
+            number: row.number,
+            email: email,
+            organizationName: organizationName,
+            alias: alias,
+            displayLabel: displayLabel !== "" ? displayLabel : "Account " + row.number,
+            active: row.active,
+            usageStatus: row.usageStatus,
+            fiveHour: fiveHour.value,
+            sevenDay: sevenDay.value,
+            scoped: parseScopedWindows(usage.scoped)
+        }
+        if (row.active)
+            activeSlots.push(row.number)
+        accounts.push(account)
+    }
+
+    var expectedActive = object.activeAccountNumber === null ? [] : [object.activeAccountNumber]
+    if (activeSlots.length !== expectedActive.length
+            || (activeSlots.length === 1 && activeSlots[0] !== expectedActive[0]))
+        return { ok: false, error: "The Claude account adapter active-account fields disagree." }
+
+    accounts.sort(function (a, b) {
+        if (a.active !== b.active)
+            return a.active ? -1 : 1
+        return a.number - b.number
+    })
+    return {
+        ok: true,
+        value: {
+            activeAccountNumber: object.activeAccountNumber,
+            accounts: accounts
+        }
+    }
+}
+
+function parseSwitch(text, requestedSlot) {
+    if (!isPositiveInteger(requestedSlot))
+        return { ok: false, error: "The requested Claude account slot is invalid." }
+    var decoded = parseJson(text, "account switch")
+    if (!decoded.ok)
+        return decoded
+    var object = decoded.value
+    var versionError = schemaError(object)
+    if (versionError !== "")
+        return { ok: false, error: versionError }
+    var reportedError = errorEnvelope(object)
+    if (reportedError !== "")
+        return { ok: false, error: reportedError }
+    if (typeof object.switched !== "boolean")
+        return { ok: false, error: "The Claude account adapter switch result has no switched flag." }
+    if (typeof object.reason !== "string" || object.reason.trim() === "")
+        return { ok: false, error: "The Claude account adapter switch result has no reason." }
+    if (!hasOwn(object, "from"))
+        return { ok: false, error: "The Claude account adapter switch result has no source account." }
+    if (object.from !== null
+            && (!isObject(object.from) || !isPositiveInteger(object.from.number)))
+        return { ok: false, error: "The Claude account adapter switch result has an invalid source account." }
+    if (!isObject(object.to) || !isPositiveInteger(object.to.number))
+        return { ok: false, error: "The Claude account adapter switch result has no target slot." }
+    if (object.to.number !== requestedSlot)
+        return { ok: false, error: "The Claude account adapter reported slot " + object.to.number
+                    + " after slot " + requestedSlot + " was requested." }
+    if (!object.switched && object.reason !== "already-active")
+        return { ok: false, error: "Account switch did not complete (" + object.reason + ")." }
+    return { ok: true, value: { switched: object.switched, reason: object.reason } }
+}
+
+function canActivate(account) {
+    if (!account || account.active)
+        return false
+    return account.usageStatus === "ok" || account.usageStatus === "api_key"
+        || account.usageStatus === "unavailable"
+}
+
+function statusError(account) {
+    if (!account)
+        return ""
+    switch (account.usageStatus) {
+    case "ok":
+        return account.fiveHour || account.sevenDay
+            || (account.scoped && account.scoped.length > 0)
+            ? "" : "No usage windows reported."
+    case "token_expired":
+        return "Token expired. Switch to this account in the adapter to refresh it."
+    case "api_key":
+        return "API-key account; subscription usage is unavailable."
+    case "keychain_unavailable":
+        return "The adapter could not read this account's Keychain entry."
+    case "no_credentials":
+        return "No stored credentials for this account slot."
+    case "unavailable":
+        return "Usage fetch failed."
+    default:
+        return "Unrecognized Claude account adapter status: " + account.usageStatus
+    }
+}

--- a/contents/ui/code/claudeAccounts.js
+++ b/contents/ui/code/claudeAccounts.js
@@ -139,25 +139,33 @@ function parseScopedWindows(raw) {
 
 // Optional per-account usage freshness. schema-v1 adapters may report when
 // each account's usage was measured so cached or last-known values are not
-// shown as fresh. usageFetchedAt (ISO 8601) wins; usageAgeSeconds (non-negative
-// seconds) is measured back from the poll time. Absent or malformed values
-// yield null, which makes the card fall back to the dataset poll timestamp.
-function parseUsageMeasuredAt(row, nowMs) {
-    if (hasOwn(row, "usageFetchedAt") && row.usageFetchedAt !== null) {
-        if (typeof row.usageFetchedAt === "string" && row.usageFetchedAt.trim() !== "") {
-            var ms = Date.parse(row.usageFetchedAt)
+// shown as fresh. The ISO 8601 timestamp wins; the non-negative age in seconds
+// is measured back from the poll time. Absent or malformed values yield null,
+// which makes the card fall back to the dataset poll timestamp.
+function parseMeasuredAt(row, nowMs, timestampKey, ageSecondsKey) {
+    if (hasOwn(row, timestampKey) && row[timestampKey] !== null) {
+        if (typeof row[timestampKey] === "string" && row[timestampKey].trim() !== "") {
+            var ms = Date.parse(row[timestampKey])
             if (!isNaN(ms))
                 return ms
         }
         return null
     }
-    if (hasOwn(row, "usageAgeSeconds") && row.usageAgeSeconds !== null) {
-        if (typeof row.usageAgeSeconds === "number" && isFinite(row.usageAgeSeconds)
-                && row.usageAgeSeconds >= 0)
-            return nowMs - Math.floor(row.usageAgeSeconds * 1000)
+    if (hasOwn(row, ageSecondsKey) && row[ageSecondsKey] !== null) {
+        if (typeof row[ageSecondsKey] === "number" && isFinite(row[ageSecondsKey])
+                && row[ageSecondsKey] >= 0)
+            return nowMs - Math.floor(row[ageSecondsKey] * 1000)
         return null
     }
     return null
+}
+
+// A live measurement is stamped with usageFetchedAt/usageAgeSeconds; the
+// last-known fallback carries the same pair renamed for lastGoodUsage.
+function parseUsageMeasuredAt(row, nowMs, usageIsLastGood) {
+    return usageIsLastGood
+        ? parseMeasuredAt(row, nowMs, "lastGoodFetchedAt", "lastGoodAgeSeconds")
+        : parseMeasuredAt(row, nowMs, "usageFetchedAt", "usageAgeSeconds")
 }
 
 function parseList(text, nowMs) {
@@ -197,11 +205,20 @@ function parseList(text, nowMs) {
         if (typeof row.usageStatus !== "string")
             return { ok: false, error: "Account " + row.number + " has no usageStatus." }
 
-        var usage = isObject(row.usage) ? row.usage : {}
-        var fiveHour = parseWindow(usage.fiveHour, row.number, "five-hour")
+        // A schema-v1 row carries either a live `usage` object or, once a fetch
+        // fails, a display-grade `lastGoodUsage` fallback in the same shape with
+        // its own measurement timestamps. Project both through the one strict
+        // window parser so cached windows are shown as non-current rather than
+        // dropped, and never let a fallback masquerade as a live measurement.
+        var live = isObject(row.usage) ? row.usage : null
+        var lastGood = live === null && isObject(row.lastGoodUsage) ? row.lastGoodUsage : null
+        var usageIsLastGood = lastGood !== null
+        var usage = live || lastGood || {}
+        var windowLabel = usageIsLastGood ? "last-known " : ""
+        var fiveHour = parseWindow(usage.fiveHour, row.number, windowLabel + "five-hour")
         if (!fiveHour.ok)
             return fiveHour
-        var sevenDay = parseWindow(usage.sevenDay, row.number, "seven-day")
+        var sevenDay = parseWindow(usage.sevenDay, row.number, windowLabel + "seven-day")
         if (!sevenDay.ok)
             return sevenDay
 
@@ -223,7 +240,8 @@ function parseList(text, nowMs) {
             fiveHour: fiveHour.value,
             sevenDay: sevenDay.value,
             scoped: parseScopedWindows(usage.scoped),
-            usageMeasuredAt: parseUsageMeasuredAt(row, nowMs)
+            usageIsLastGood: usageIsLastGood,
+            usageMeasuredAt: parseUsageMeasuredAt(row, nowMs, usageIsLastGood)
         }
         if (row.active)
             activeSlots.push(row.number)
@@ -281,11 +299,18 @@ function parseSwitch(text, requestedSlot) {
     return { ok: true, value: { switched: object.switched, reason: object.reason } }
 }
 
+// Statuses an explicit switch can act on. "unavailable" only means the usage
+// fetch failed, and both credential faults below are what a switch repairs:
+// switching refreshes an expired token, and it stashes a foreign credential
+// before restoring the slot's own. The remaining statuses need the user to
+// re-login or unlock a keychain first, so they stay non-actionable here
+// instead of offering a button that cannot succeed.
+var SWITCHABLE_STATUSES = ["ok", "api_key", "unavailable", "token_expired", "foreign_credential"]
+
 function canActivate(account) {
     if (!account || account.active)
         return false
-    return account.usageStatus === "ok" || account.usageStatus === "api_key"
-        || account.usageStatus === "unavailable"
+    return SWITCHABLE_STATUSES.indexOf(account.usageStatus) >= 0
 }
 
 function statusError(account) {
@@ -297,7 +322,11 @@ function statusError(account) {
             || (account.scoped && account.scoped.length > 0)
             ? "" : "No usage windows reported."
     case "token_expired":
-        return "Token expired. Switch to this account in the adapter to refresh it."
+        return "Token expired. Switch to this account to refresh it."
+    case "foreign_credential":
+        return "The stored credential belongs to another account. Switch to this account to repair it."
+    case "relogin_required":
+        return "The stored login is no longer valid. Re-login with the adapter to restore this account."
     case "api_key":
         return "API-key account; subscription usage is unavailable."
     case "keychain_unavailable":

--- a/contents/ui/code/claudeAccounts.js
+++ b/contents/ui/code/claudeAccounts.js
@@ -164,7 +164,9 @@ function parseScopedWindows(raw) {
                 || typeof row.pct !== "number" || !isFinite(row.pct))
             continue
         var resetsAt = null
-        if (hasOwn(row, "resetsAt")) {
+        // Match account-wide windows: an explicit JSON null means the adapter
+        // has no reset timestamp, not that the scoped window is malformed.
+        if (hasOwn(row, "resetsAt") && row.resetsAt !== null) {
             if (typeof row.resetsAt !== "string" || row.resetsAt.trim() === ""
                     || isNaN(Date.parse(row.resetsAt)))
                 continue

--- a/contents/ui/code/claudeAccounts.js
+++ b/contents/ui/code/claudeAccounts.js
@@ -83,7 +83,21 @@ function schemaError(object) {
     return ""
 }
 
-function parseWindow(raw, slot, name) {
+// Weekly windows (sevenDay and scoped, never fiveHour) additively carry the
+// adapter's own pace verdict. Reading it beats recomputing one locally: the
+// adapter measures against the real fetch time and applies its own suppression
+// rules for the first day or so of the week. Its projected-exhaustion fields
+// are deliberately not read — claude-swap keeps that linear extrapolation out
+// of every human surface because the error bars are too wide to state as fact.
+function parsePace(raw) {
+    return {
+        expectedPct: (typeof raw.expectedPct === "number" && isFinite(raw.expectedPct))
+            ? Math.max(0, Math.min(100, raw.expectedPct)) : null,
+        aheadOfPace: typeof raw.aheadOfPace === "boolean" ? raw.aheadOfPace : null
+    }
+}
+
+function parseWindow(raw, slot, name, weekly) {
     if (raw === undefined || raw === null)
         return { ok: true, value: null }
     if (!isObject(raw))
@@ -99,13 +113,42 @@ function parseWindow(raw, slot, name) {
             return { ok: false, error: "Account " + slot + " has an invalid " + name + " reset timestamp." }
         resetsAt = raw.resetsAt
     }
+    var pace = weekly === true ? parsePace(raw) : { expectedPct: null, aheadOfPace: null }
     return {
         ok: true,
         value: {
             usedPercent: Math.max(0, Math.min(100, raw.pct)),
             resetsAt: resetsAt,
+            expectedPct: pace.expectedPct,
+            aheadOfPace: pace.aheadOfPace,
             usageKnown: true
         }
+    }
+}
+
+// usage.spend is additive schema-v1 pay-as-you-go data, and per-account: the
+// CodexBar CLI can only report cost for whichever account is currently active.
+// Malformed values are ignored rather than fatal, matching parseScopedWindows,
+// so an unfamiliar spend shape cannot suppress the usage windows next to it.
+function parseSpend(raw) {
+    if (!isObject(raw))
+        return null
+    if (typeof raw.pct !== "number" || !isFinite(raw.pct)
+            || typeof raw.used !== "number" || !isFinite(raw.used)
+            || typeof raw.limit !== "number" || !isFinite(raw.limit))
+        return null
+    var resetsAt = null
+    if (hasOwn(raw, "resetsAt") && raw.resetsAt !== null
+            && typeof raw.resetsAt === "string" && raw.resetsAt.trim() !== ""
+            && !isNaN(Date.parse(raw.resetsAt)))
+        resetsAt = raw.resetsAt
+    return {
+        used: raw.used,
+        limit: raw.limit,
+        currency: typeof raw.currency === "string" ? raw.currency.trim() : "",
+        usedPercent: Math.max(0, Math.min(100, raw.pct)),
+        resetsAt: resetsAt,
+        usageKnown: true
     }
 }
 
@@ -127,10 +170,13 @@ function parseScopedWindows(raw) {
                 continue
             resetsAt = row.resetsAt
         }
+        var pace = parsePace(row)
         windows.push({
             name: row.name.trim(),
             usedPercent: Math.max(0, Math.min(100, row.pct)),
             resetsAt: resetsAt,
+            expectedPct: pace.expectedPct,
+            aheadOfPace: pace.aheadOfPace,
             usageKnown: true
         })
     }
@@ -215,10 +261,10 @@ function parseList(text, nowMs) {
         var usageIsLastGood = lastGood !== null
         var usage = live || lastGood || {}
         var windowLabel = usageIsLastGood ? "last-known " : ""
-        var fiveHour = parseWindow(usage.fiveHour, row.number, windowLabel + "five-hour")
+        var fiveHour = parseWindow(usage.fiveHour, row.number, windowLabel + "five-hour", false)
         if (!fiveHour.ok)
             return fiveHour
-        var sevenDay = parseWindow(usage.sevenDay, row.number, windowLabel + "seven-day")
+        var sevenDay = parseWindow(usage.sevenDay, row.number, windowLabel + "seven-day", true)
         if (!sevenDay.ok)
             return sevenDay
 
@@ -245,6 +291,7 @@ function parseList(text, nowMs) {
             fiveHour: fiveHour.value,
             sevenDay: sevenDay.value,
             scoped: parseScopedWindows(usage.scoped),
+            spend: parseSpend(usage.spend),
             usageIsLastGood: usageIsLastGood,
             usageMeasuredAt: parseUsageMeasuredAt(row, nowMs, usageIsLastGood)
         }
@@ -270,6 +317,34 @@ function parseList(text, nowMs) {
             accounts: accounts
         }
     }
+}
+
+var MAX_SWITCH_WARNINGS = 6
+
+// A schema-v1 switch result carries warnings that exist nowhere else: in --json
+// mode the adapter routes them into the payload instead of stderr, and they
+// report credential damage the user has to act on (live tokens wiped by Claude
+// Code, a foreign credential left in place, a session-mode instance racing the
+// default login). A switch can report switched: true and still warn, so these
+// are surfaced independently of the success path.
+function parseWarnings(raw) {
+    if (!Array.isArray(raw))
+        return []
+    var warnings = []
+    var dropped = 0
+    for (var i = 0; i < raw.length; i++) {
+        if (typeof raw[i] !== "string" || raw[i].trim() === "")
+            continue
+        if (warnings.length >= MAX_SWITCH_WARNINGS) {
+            dropped++
+            continue
+        }
+        warnings.push(raw[i].trim())
+    }
+    // Say what was held back rather than truncating a credential warning away.
+    if (dropped > 0)
+        warnings.push(dropped + " more adapter warning(s) not shown.")
+    return warnings
 }
 
 function parseSwitch(text, requestedSlot) {
@@ -299,9 +374,31 @@ function parseSwitch(text, requestedSlot) {
     if (object.to.number !== requestedSlot)
         return { ok: false, error: "The Claude account adapter reported slot " + object.to.number
                     + " after slot " + requestedSlot + " was requested." }
+    var warnings = parseWarnings(object.warnings)
     if (!object.switched && object.reason !== "already-active")
-        return { ok: false, error: "Account switch did not complete (" + object.reason + ")." }
-    return { ok: true, value: { switched: object.switched, reason: object.reason } }
+        return {
+            ok: false,
+            error: "Account switch did not complete (" + object.reason + ").",
+            warnings: warnings
+        }
+    return {
+        ok: true,
+        value: { switched: object.switched, reason: object.reason, warnings: warnings }
+    }
+}
+
+// The adapter's pace verdict, phrased in the vocabulary the CLI-backed cards
+// already use. There is no exhaustion estimate here on purpose; see parsePace.
+function paceText(win) {
+    if (!win || typeof win.expectedPct !== "number")
+        return ""
+    var delta = win.usedPercent - win.expectedPct
+    var magnitude = Math.round(Math.abs(delta))
+    if (win.aheadOfPace === true)
+        return magnitude > 0 ? "Pace: " + magnitude + "% in deficit" : "Pace: Ahead of pace"
+    if (magnitude === 0 || Math.abs(delta) <= 2)
+        return "Pace: On pace"
+    return "Pace: " + magnitude + "% " + (delta > 0 ? "in deficit" : "in reserve")
 }
 
 // Statuses an explicit switch can act on. "unavailable" only means the usage

--- a/contents/ui/code/claudeAccounts.js
+++ b/contents/ui/code/claudeAccounts.js
@@ -137,7 +137,32 @@ function parseScopedWindows(raw) {
     return windows
 }
 
-function parseList(text) {
+// Optional per-account usage freshness. schema-v1 adapters may report when
+// each account's usage was measured so cached or last-known values are not
+// shown as fresh. usageFetchedAt (ISO 8601) wins; usageAgeSeconds (non-negative
+// seconds) is measured back from the poll time. Absent or malformed values
+// yield null, which makes the card fall back to the dataset poll timestamp.
+function parseUsageMeasuredAt(row, nowMs) {
+    if (hasOwn(row, "usageFetchedAt") && row.usageFetchedAt !== null) {
+        if (typeof row.usageFetchedAt === "string" && row.usageFetchedAt.trim() !== "") {
+            var ms = Date.parse(row.usageFetchedAt)
+            if (!isNaN(ms))
+                return ms
+        }
+        return null
+    }
+    if (hasOwn(row, "usageAgeSeconds") && row.usageAgeSeconds !== null) {
+        if (typeof row.usageAgeSeconds === "number" && isFinite(row.usageAgeSeconds)
+                && row.usageAgeSeconds >= 0)
+            return nowMs - Math.floor(row.usageAgeSeconds * 1000)
+        return null
+    }
+    return null
+}
+
+function parseList(text, nowMs) {
+    if (nowMs === undefined)
+        nowMs = Date.now()
     var decoded = parseJson(text, "account list")
     if (!decoded.ok)
         return decoded
@@ -197,7 +222,8 @@ function parseList(text) {
             usageStatus: row.usageStatus,
             fiveHour: fiveHour.value,
             sevenDay: sevenDay.value,
-            scoped: parseScopedWindows(usage.scoped)
+            scoped: parseScopedWindows(usage.scoped),
+            usageMeasuredAt: parseUsageMeasuredAt(row, nowMs)
         }
         if (row.active)
             activeSlots.push(row.number)

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -15,6 +15,8 @@ KCM.SimpleKCM {
     property alias cfg_showCost: showCost.checked
     property alias cfg_showStatus: showStatus.checked
     property alias cfg_cliPath: cliPath.text
+    property alias cfg_enableClaudeAccounts: enableClaudeAccounts.checked
+    property alias cfg_claudeAdapterPath: claudeAdapterPath.text
     property string cfg_panelPercentSource
     property string cfg_percentStyle
 
@@ -135,6 +137,30 @@ KCM.SimpleKCM {
             Kirigami.FormData.label: i18n("codexbar CLI path:")
             placeholderText: i18n("auto (codexbar in PATH)")
             Layout.fillWidth: true
+        }
+
+        Item { Kirigami.FormData.isSection: true }
+
+        QQC2.CheckBox {
+            id: enableClaudeAccounts
+            Kirigami.FormData.label: i18n("Claude accounts:")
+            text: i18n("Show all accounts from a schema-v1 adapter")
+        }
+
+        QQC2.TextField {
+            id: claudeAdapterPath
+            Kirigami.FormData.label: i18n("Adapter executable path:")
+            enabled: enableClaudeAccounts.checked
+            placeholderText: i18n("auto (cswap in PATH)")
+            Layout.fillWidth: true
+        }
+
+        QQC2.Label {
+            Layout.fillWidth: true
+            enabled: enableClaudeAccounts.checked
+            text: i18n("The widget only runs --list --json and an explicitly selected --switch-to <slot> --json operation.")
+            wrapMode: Text.WordWrap
+            opacity: 0.7
         }
     }
 }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -62,6 +62,7 @@ PlasmoidItem {
         loading: false,
         error: "",
         switchError: "",
+        switchWarnings: [],
         fetchedAt: 0
     })
     property var pendingClaudeList: ({})
@@ -162,6 +163,7 @@ PlasmoidItem {
             loading: false,
             error: "",
             switchError: "",
+            switchWarnings: [],
             fetchedAt: 0
         }
         bump()
@@ -218,7 +220,7 @@ PlasmoidItem {
             return
         claudeSwitchInFlight = true
         claudeSwitchingSlot = slot
-        updateClaudeAccountData({ switchError: "" })
+        updateClaudeAccountData({ switchError: "", switchWarnings: [] })
         pendingClaudeSwitch[cmd] = { adapterGen: claudeAdapterGen, slot: slot }
         executable.connectSource(cmd)
     }
@@ -379,9 +381,13 @@ PlasmoidItem {
             claudeSwitchingSlot = 0
             if (switchReq.adapterGen === claudeAdapterGen) {
                 var parsedSwitch = ClaudeAccounts.parseSwitch(stdout, switchReq.slot)
+                // Adapter warnings ride along with both outcomes: a switch can
+                // report success and still warn that a credential needs repair.
                 updateClaudeAccountData({
                     switchError: parsedSwitch.ok ? ""
-                        : claudeAdapterErrorText(exitCode, parsedSwitch.error)
+                        : claudeAdapterErrorText(exitCode, parsedSwitch.error),
+                    switchWarnings: parsedSwitch.ok ? parsedSwitch.value.warnings
+                                                    : (parsedSwitch.warnings || [])
                 })
             } else {
                 bump()

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -139,8 +139,13 @@ PlasmoidItem {
             return prefix + "timeout -k 5 30 sh -c " + shellQuote(pipeline)
         }
         if (operation === "switch" && typeof slot === "number" && isFinite(slot)
-                && Math.floor(slot) === slot && slot > 0)
-            return prefix + quoted + " --switch-to " + slot + " --json 2>/dev/null"
+                && Math.floor(slot) === slot && slot > 0) {
+            // Bound the switch like the list probe so a hung adapter (credential
+            // lock, keychain prompt, or backend call) cannot leave
+            // claudeSwitchInFlight set and disable every switch button until
+            // the plasmoid is reloaded.
+            return prefix + "timeout -k 5 30 " + quoted + " --switch-to " + slot + " --json 2>/dev/null"
+        }
         return ""
     }
 
@@ -218,12 +223,20 @@ PlasmoidItem {
         executable.connectSource(cmd)
     }
 
-    function isClaudeAccountDataStale() {
+    // Per-account staleness: prefer the adapter's reported usage measurement
+    // time, falling back to the dataset poll timestamp when the adapter did
+    // not report freshness. This keeps cached/last-known usage from reading as
+    // fresh just because the widget polled again.
+    function isClaudeAccountStale(account) {
         rev
-        if (!claudeAccountData.valid || !claudeAccountData.fetchedAt)
+        if (!claudeAccountData.valid)
+            return true
+        var ts = (account && typeof account.usageMeasuredAt === "number")
+            ? account.usageMeasuredAt : claudeAccountData.fetchedAt
+        if (!ts)
             return true
         var maxAge = Math.max(1, Plasmoid.configuration.refreshIntervalMinutes) * 60000 * 3
-        return (Date.now() - claudeAccountData.fetchedAt) > maxAge
+        return (Date.now() - ts) > maxAge
     }
 
     function refreshAll(force) {
@@ -333,9 +346,10 @@ PlasmoidItem {
                     refreshClaudeAccounts()
                 return
             }
+            var listNowMs = Date.now()
             var parsedAccounts = (exitCode === 124 || exitCode === 137)
                 ? { ok: false, error: "" }
-                : ClaudeAccounts.parseList(stdout)
+                : ClaudeAccounts.parseList(stdout, listNowMs)
             if (parsedAccounts.ok) {
                 updateClaudeAccountData({
                     valid: true,
@@ -343,7 +357,7 @@ PlasmoidItem {
                     activeAccountNumber: parsedAccounts.value.activeAccountNumber,
                     loading: false,
                     error: "",
-                    fetchedAt: Date.now()
+                    fetchedAt: listNowMs
                 })
             } else {
                 updateClaudeAccountData({

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -5,6 +5,7 @@ import org.kde.plasma.core as PlasmaCore
 import org.kde.plasma.plasma5support as P5Support
 import org.kde.kirigami as Kirigami
 import "code/catalog.js" as Catalog
+import "code/claudeAccounts.js" as ClaudeAccounts
 
 PlasmoidItem {
     id: root
@@ -44,6 +45,32 @@ PlasmoidItem {
     // per-provider request generation: responses from an older generation
     // (e.g. after a config change re-triggered a refresh) are discarded
     property var requestGen: ({})
+
+    // Optional schema-v1 claude-swap-compatible adapter state. Normal Claude
+    // usage/cost queries remain active for the panel, overview and fallback UI.
+    readonly property bool claudeAccountsEnabled:
+        Plasmoid.configuration.enableClaudeAccounts
+        && enabledProviders.indexOf("claude") >= 0
+    readonly property string claudeAdapterExecutable: {
+        var configured = (Plasmoid.configuration.claudeAdapterPath || "").trim()
+        return configured.length > 0 ? configured : "cswap"
+    }
+    property var claudeAccountData: ({
+        valid: false,
+        accounts: [],
+        activeAccountNumber: null,
+        loading: false,
+        error: "",
+        switchError: "",
+        fetchedAt: 0
+    })
+    property var pendingClaudeList: ({})
+    property var pendingClaudeSwitch: ({})
+    property int claudeAdapterGen: 0
+    property int claudeListGen: 0
+    property bool claudeSwitchInFlight: false
+    property int claudeSwitchingSlot: 0
+    property bool componentReady: false
 
     // must fit the full representation (19 grid units wide) before switching
     switchWidth: Kirigami.Units.gridUnit * 19
@@ -86,11 +113,117 @@ PlasmoidItem {
         return "'" + s.replace(/'/g, "'\\''") + "'"
     }
 
+    function shellQuoteExecutable(s) {
+        // A settings UI commonly receives ~/.local/bin/...; expand only this
+        // leading home shorthand and quote the entire remaining path.
+        if (s.indexOf("~/") === 0)
+            return '"$HOME"/' + shellQuote(s.substring(2))
+        return shellQuote(s)
+    }
+
     function cliCmd(args) {
         var exe = (Plasmoid.configuration.cliPath || "").trim()
         var quoted = exe.length > 0 ? shellQuote(exe) : "codexbar"
         // -k 10: hard-kill if SIGTERM is ignored after the 120s timeout
         return 'PATH="$HOME/.local/bin:$PATH"; timeout -k 10 120 ' + quoted + " " + args + " 2>/dev/null"
+    }
+
+    function claudeAdapterCmd(operation, slot) {
+        var quoted = shellQuoteExecutable(claudeAdapterExecutable)
+        var prefix = 'PATH="$HOME/.local/bin:$PATH"; '
+        if (operation === "list") {
+            // Bound what Plasma's executable data engine can capture, while
+            // retaining one extra byte so the parser can report overflow.
+            var pipeline = quoted + " --list --json 2>/dev/null | head -c "
+                + (ClaudeAccounts.MAX_OUTPUT_BYTES + 1)
+            return prefix + "timeout -k 5 30 sh -c " + shellQuote(pipeline)
+        }
+        if (operation === "switch" && typeof slot === "number" && isFinite(slot)
+                && Math.floor(slot) === slot && slot > 0)
+            return prefix + quoted + " --switch-to " + slot + " --json 2>/dev/null"
+        return ""
+    }
+
+    function updateClaudeAccountData(changes) {
+        claudeAccountData = Object.assign({}, claudeAccountData, changes)
+        bump()
+    }
+
+    function clearClaudeAccountData() {
+        claudeAccountData = {
+            valid: false,
+            accounts: [],
+            activeAccountNumber: null,
+            loading: false,
+            error: "",
+            switchError: "",
+            fetchedAt: 0
+        }
+        bump()
+    }
+
+    function refreshClaudeAccounts() {
+        if (!claudeAccountsEnabled || claudeSwitchInFlight)
+            return
+        var cmd = claudeAdapterCmd("list", 0)
+        if (cmd === "" || pendingClaudeList[cmd] !== undefined)
+            return
+        var listGen = ++claudeListGen
+        pendingClaudeList[cmd] = { adapterGen: claudeAdapterGen, listGen: listGen }
+        updateClaudeAccountData({ loading: true })
+        executable.connectSource(cmd)
+    }
+
+    function claudeAdapterErrorText(exitCode, parseError) {
+        if (exitCode === 124 || exitCode === 137)
+            return "Timed out querying the Claude account adapter."
+        if (exitCode === 127)
+            return "Claude account adapter not found — set its executable path in the settings."
+        if (parseError && parseError.length > 0)
+            return parseError
+        if (exitCode === 0)
+            return "The Claude account adapter returned no account data."
+        return "Claude account adapter failed (exit " + exitCode + ")."
+    }
+
+    function claudeAccountForSlot(slot) {
+        var accounts = claudeAccountData.accounts || []
+        for (var i = 0; i < accounts.length; i++) {
+            if (accounts[i].number === slot)
+                return accounts[i]
+        }
+        return null
+    }
+
+    function canSwitchClaudeAccount(account) {
+        return claudeAccountsEnabled && claudeAccountData.valid
+            && !claudeAccountData.loading && !claudeSwitchInFlight
+            && ClaudeAccounts.canActivate(account)
+    }
+
+    function switchClaudeAccount(slot) {
+        if (claudeSwitchInFlight || typeof slot !== "number" || !isFinite(slot)
+                || Math.floor(slot) !== slot || slot <= 0)
+            return
+        var account = claudeAccountForSlot(slot)
+        if (!canSwitchClaudeAccount(account))
+            return
+        var cmd = claudeAdapterCmd("switch", slot)
+        if (cmd === "" || pendingClaudeSwitch[cmd] !== undefined)
+            return
+        claudeSwitchInFlight = true
+        claudeSwitchingSlot = slot
+        updateClaudeAccountData({ switchError: "" })
+        pendingClaudeSwitch[cmd] = { adapterGen: claudeAdapterGen, slot: slot }
+        executable.connectSource(cmd)
+    }
+
+    function isClaudeAccountDataStale() {
+        rev
+        if (!claudeAccountData.valid || !claudeAccountData.fetchedAt)
+            return true
+        var maxAge = Math.max(1, Plasmoid.configuration.refreshIntervalMinutes) * 60000 * 3
+        return (Date.now() - claudeAccountData.fetchedAt) > maxAge
     }
 
     function refreshAll(force) {
@@ -99,6 +232,9 @@ PlasmoidItem {
             if (force === true || !autoRefreshBlocked[provider])
                 refreshProvider(provider)
         }
+        // The account adapter is a separate executable from the codexbar CLI,
+        // so a CLI crash block must not suppress its polling.
+        refreshClaudeAccounts()
     }
 
     function supportsCost(p) {
@@ -186,6 +322,60 @@ PlasmoidItem {
     }
 
     function handleData(source, exitCode, stdout) {
+        var accountReq = pendingClaudeList[source]
+        if (accountReq !== undefined) {
+            delete pendingClaudeList[source]
+            if (accountReq.adapterGen !== claudeAdapterGen || accountReq.listGen !== claudeListGen) {
+                // A disable/re-enable or path edit may resolve to the same
+                // command string. Once the old source is disconnected, start
+                // the fresh generation that was previously de-duplicated.
+                if (claudeAccountsEnabled)
+                    refreshClaudeAccounts()
+                return
+            }
+            var parsedAccounts = (exitCode === 124 || exitCode === 137)
+                ? { ok: false, error: "" }
+                : ClaudeAccounts.parseList(stdout)
+            if (parsedAccounts.ok) {
+                updateClaudeAccountData({
+                    valid: true,
+                    accounts: parsedAccounts.value.accounts,
+                    activeAccountNumber: parsedAccounts.value.activeAccountNumber,
+                    loading: false,
+                    error: "",
+                    fetchedAt: Date.now()
+                })
+            } else {
+                updateClaudeAccountData({
+                    loading: false,
+                    error: claudeAdapterErrorText(exitCode, parsedAccounts.error)
+                })
+            }
+            return
+        }
+
+        var switchReq = pendingClaudeSwitch[source]
+        if (switchReq !== undefined) {
+            delete pendingClaudeSwitch[source]
+            claudeSwitchInFlight = false
+            claudeSwitchingSlot = 0
+            if (switchReq.adapterGen === claudeAdapterGen) {
+                var parsedSwitch = ClaudeAccounts.parseSwitch(stdout, switchReq.slot)
+                updateClaudeAccountData({
+                    switchError: parsedSwitch.ok ? ""
+                        : claudeAdapterErrorText(exitCode, parsedSwitch.error)
+                })
+            } else {
+                bump()
+            }
+            // Switching affects both the adapter projection and the ambient
+            // Claude snapshot used by panel/overview/status/cost UI.
+            if (enabledProviders.indexOf("claude") >= 0)
+                refreshProvider("claude")
+            refreshClaudeAccounts()
+            return
+        }
+
         var req = pendingUsage[source]
         if (req !== undefined) {
             delete pendingUsage[source]
@@ -313,9 +503,30 @@ PlasmoidItem {
     }
 
     Component.onCompleted: {
+        componentReady = true
         currentTab = defaultTab()
         deferAutomaticCostScans()
         refreshAll(false)
+    }
+
+    onClaudeAccountsEnabledChanged: {
+        if (!componentReady)
+            return
+        claudeAdapterGen++
+        claudeListGen++
+        clearClaudeAccountData()
+        if (claudeAccountsEnabled)
+            refreshClaudeAccounts()
+    }
+
+    onClaudeAdapterExecutableChanged: {
+        if (!componentReady)
+            return
+        claudeAdapterGen++
+        claudeListGen++
+        clearClaudeAccountData()
+        if (claudeAccountsEnabled)
+            refreshClaudeAccounts()
     }
 
     onEnabledProvidersChanged: {

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -231,6 +231,10 @@ PlasmoidItem {
         rev
         if (!claudeAccountData.valid)
             return true
+        // Last-known windows are served because the live fetch failed, so they
+        // are non-current regardless of how recently they were measured.
+        if (account && account.usageIsLastGood === true)
+            return true
         var ts = (account && typeof account.usageMeasuredAt === "number")
             ? account.usageMeasuredAt : claudeAccountData.fetchedAt
         if (!ts)

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -143,9 +143,12 @@ PlasmoidItem {
                 && Math.floor(slot) === slot && slot > 0) {
             // Bound the switch like the list probe so a hung adapter (credential
             // lock, keychain prompt, or backend call) cannot leave
-            // claudeSwitchInFlight set and disable every switch button until
-            // the plasmoid is reloaded.
-            return prefix + "timeout -k 5 30 " + quoted + " --switch-to " + slot + " --json 2>/dev/null"
+            // claudeSwitchInFlight set, and cap its captured output just like
+            // the automatic list response.
+            var switchPipeline = quoted + " --switch-to " + slot
+                + " --json 2>/dev/null | head -c "
+                + (ClaudeAccounts.MAX_OUTPUT_BYTES + 1)
+            return prefix + "timeout -k 5 30 sh -c " + shellQuote(switchPipeline)
         }
         return ""
     }


### PR DESCRIPTION
## Summary

- add an optional schema-v1 Claude account adapter view
- show per-account 5-hour, 7-day, scoped, and pay-as-you-go usage
- support explicit account switching with serialized, timeout-bounded requests
- preserve adapter freshness, last-known usage, warnings, rotation state, and identity fields
- display identity as `alias > organizationName > email`
- keep the normal Claude provider card as a safe fallback for missing or invalid adapter data

## Compatibility

The adapter remains optional and credential-free. Existing schema-v1 adapters that only provide email continue to work; current claude-swap identity and freshness fields are retained when present. Adapter output is capped at 256 KiB for both listing and switching operations.

## Verification

- rebased onto `psimaker/codexbar-plasmoid` `main` at `b7adf77` (v0.2.2)
- targeted parser matrix for identity, freshness, last-known usage, statuses, warnings, spend, pace, scoped windows, and switch results
- `qmllint contents/ui/*.qml`
- `xmllint --noout contents/config/main.xml`
- `jq empty metadata.json`
- `kpackagetool6 -t Plasma/Applet --hash <package>`
- `git diff --check`
