### PR TITLE
Improve provider tab spacing and overflow navigation

### DIFF
--- a/contents/ui/FullView.qml
+++ b/contents/ui/FullView.qml
@@ -21,6 +21,20 @@ Item {
     }
     readonly property string currentTab: plasmoidRoot.currentTab
     readonly property bool onProviderTab: Catalog.PROVIDERS[currentTab] !== undefined
+    readonly property real popupBaseWidth: Kirigami.Units.gridUnit * 19
+    readonly property int initiallyVisibleTabs: 4
+
+    FontMetrics {
+        id: tabFontMetrics
+        font: Kirigami.Theme.smallFont
+    }
+
+    function naturalTabWidth(tabId) {
+        var label = tabId === "overview" ? i18n("Overview") : Catalog.meta(tabId).name
+        return Math.max(Kirigami.Units.gridUnit * 3.5,
+                        Math.ceil(tabFontMetrics.advanceWidth(label)
+                                  + Kirigami.Units.smallSpacing * 4))
+    }
 
     // cap the popup height to the usable screen area (fallback: 42 grid units)
     readonly property real popupMaxHeight: {
@@ -30,15 +44,34 @@ Item {
             cap = Math.min(cap, rect.height - Kirigami.Units.gridUnit * 3)
         return Math.max(cap, Kirigami.Units.gridUnit * 12)
     }
+    readonly property real popupMaxWidth: {
+        var cap = Kirigami.Units.gridUnit * 42
+        var rect = Plasmoid.availableScreenRect
+        if (rect && rect.width > 0)
+            cap = Math.min(cap, rect.width - Kirigami.Units.gridUnit * 3)
+        return Math.max(cap, popupBaseWidth)
+    }
+    readonly property real initialTabStripWidth: {
+        var width = 0
+        var count = Math.min(tabs.length, initiallyVisibleTabs)
+        for (var i = 0; i < count; ++i)
+            width += naturalTabWidth(tabs[i])
+        return width
+    }
+    readonly property real overflowControlsWidth: tabs.length > initiallyVisibleTabs
+                                                   ? Kirigami.Units.iconSizes.smallMedium * 2 : 0
+    readonly property real desiredPopupWidth: initialTabStripWidth
+                                               + overflowControlsWidth
+                                               + Kirigami.Units.largeSpacing * 2
 
-    implicitWidth: Kirigami.Units.gridUnit * 19
+    implicitWidth: Math.min(Math.max(popupBaseWidth, desiredPopupWidth), popupMaxWidth)
     implicitHeight: Math.min(mainColumn.implicitHeight + Kirigami.Units.largeSpacing * 2,
                              popupMaxHeight)
 
     // the panel popup sizes itself from these hints, not from implicit size
-    Layout.minimumWidth: Kirigami.Units.gridUnit * 19
-    Layout.preferredWidth: Kirigami.Units.gridUnit * 19
-    Layout.maximumWidth: Kirigami.Units.gridUnit * 19
+    Layout.minimumWidth: implicitWidth
+    Layout.preferredWidth: implicitWidth
+    Layout.maximumWidth: implicitWidth
     Layout.minimumHeight: implicitHeight
     Layout.preferredHeight: implicitHeight
     Layout.maximumHeight: implicitHeight
@@ -56,125 +89,206 @@ Item {
         boundsBehavior: Flickable.StopAtBounds
 
         PlasmaComponents3.ScrollBar.vertical: PlasmaComponents3.ScrollBar {
+            id: verticalScrollBar
             visible: flick.contentHeight > flick.height
         }
 
         ColumnLayout {
             id: mainColumn
-            width: flick.width
+            width: flick.width - (verticalScrollBar.visible
+                                  ? verticalScrollBar.width + Kirigami.Units.smallSpacing
+                                  : 0)
             spacing: Kirigami.Units.smallSpacing
 
             // ---- provider switcher ----
-            RowLayout {
+            Item {
                 id: tabStrip
+                readonly property bool overflowing: tabList.contentWidth > tabList.width + 1
                 Layout.fillWidth: true
                 Layout.bottomMargin: Kirigami.Units.smallSpacing
+                Layout.preferredHeight: Kirigami.Units.gridUnit * 2.9
                 visible: fullRoot.currentTab !== "about" && fullRoot.tabs.length > 1
-                spacing: 0
+                clip: true
 
-                Repeater {
-                    model: fullRoot.tabs
+                RowLayout {
+                    anchors.fill: parent
+                    spacing: 0
 
-                    Item {
-                        id: tab
-                        required property string modelData
-                        readonly property string tabId: modelData
-                        readonly property bool isOverview: tabId === "overview"
-                        readonly property bool selected: fullRoot.currentTab === tabId
-                        readonly property var meta: Catalog.meta(tabId)
-                        readonly property real remaining:
-                            isOverview ? -1 : fullRoot.plasmoidRoot.remainingPercent(tabId, "session")
+                    PlasmaComponents3.ToolButton {
+                        visible: tabStrip.overflowing
+                        enabled: !tabList.atXBeginning
+                        Layout.preferredWidth: Kirigami.Units.iconSizes.smallMedium
+                        Layout.fillHeight: true
+                        icon.name: "go-previous-symbolic"
+                        onClicked: tabList.scrollByPage(-1)
+                    }
 
+                    Flickable {
+                        id: tabList
                         Layout.fillWidth: true
-                        Layout.preferredHeight: Kirigami.Units.gridUnit * 2.9
+                        Layout.fillHeight: true
+                        contentWidth: tabRow.implicitWidth
+                        contentHeight: height
+                        clip: true
+                        boundsBehavior: Flickable.StopAtBounds
+                        flickableDirection: Flickable.AutoFlickIfNeeded
+                        readonly property int currentIndex:
+                            Math.max(0, fullRoot.tabs.indexOf(fullRoot.currentTab))
 
-                        Rectangle {
-                            id: plate
-                            anchors.top: parent.top
-                            anchors.left: parent.left
-                            anchors.right: parent.right
-                            anchors.margins: 2
-                            height: parent.height - 8
-                            radius: Kirigami.Units.cornerRadius + 2
-                            color: tab.selected
-                                   ? Kirigami.Theme.highlightColor
-                                   : (tabMouse.containsMouse
-                                      ? Qt.alpha(Kirigami.Theme.textColor, 0.06)
-                                      : "transparent")
+                        function scrollByPage(direction) {
+                            var limit = Math.max(0, contentWidth - width)
+                            var step = Math.max(width * 0.7, Kirigami.Units.gridUnit * 4)
+                            contentX = Math.max(0, Math.min(limit, contentX + direction * step))
+                        }
 
-                            ColumnLayout {
-                                anchors.centerIn: parent
-                                spacing: Math.round(Kirigami.Units.smallSpacing / 2)
+                        function revealIndex(index) {
+                            if (index < 0 || index >= fullRoot.tabs.length || width <= 0)
+                                return
 
-                                Item {
-                                    Layout.alignment: Qt.AlignHCenter
-                                    Layout.preferredWidth: Kirigami.Units.iconSizes.smallMedium
-                                    Layout.preferredHeight: Kirigami.Units.iconSizes.smallMedium
+                            var left = 0
+                            for (var i = 0; i < index; ++i)
+                                left += fullRoot.naturalTabWidth(fullRoot.tabs[i])
 
-                                    // 2×2 grid of rounded squares, like the original
-                                    // Overview tab icon (crisp in light and dark mode)
-                                    Grid {
-                                        visible: tab.isOverview
-                                        anchors.centerIn: parent
-                                        rows: 2
-                                        columns: 2
-                                        spacing: Math.max(2, Math.round(parent.width * 0.14))
+                            var right = left + fullRoot.naturalTabWidth(fullRoot.tabs[index])
+                            var margin = Kirigami.Units.smallSpacing
+                            var limit = Math.max(0, contentWidth - width)
 
-                                        Repeater {
-                                            model: 4
-                                            Rectangle {
-                                                width: Math.round(Kirigami.Units.iconSizes.smallMedium * 0.36)
-                                                height: width
-                                                radius: Math.max(2, width * 0.3)
+                            if (left < contentX + margin)
+                                contentX = Math.max(0, left - margin)
+                            else if (right > contentX + width - margin)
+                                contentX = Math.min(limit, right - width + margin)
+                        }
+
+                        onCurrentIndexChanged: Qt.callLater(function () {
+                            if (currentIndex >= 0)
+                                revealIndex(currentIndex)
+                        })
+                        onWidthChanged: Qt.callLater(function () { revealIndex(currentIndex) })
+
+                        Kirigami.WheelHandler {
+                            target: tabList
+                        }
+
+                        Row {
+                            id: tabRow
+                            height: parent.height
+                            spacing: 0
+
+                            Repeater {
+                                model: fullRoot.tabs
+
+                                delegate: Item {
+                                    id: tab
+                                    required property string modelData
+                                    readonly property string tabId: modelData
+                                    readonly property bool isOverview: tabId === "overview"
+                                    readonly property bool selected: fullRoot.currentTab === tabId
+                                    readonly property var meta: Catalog.meta(tabId)
+                                    readonly property real remaining:
+                                        isOverview ? -1 : fullRoot.plasmoidRoot.remainingPercent(tabId, "session")
+
+                                    width: fullRoot.naturalTabWidth(tabId)
+                                    height: tabList.height
+
+                                    Rectangle {
+                                        id: plate
+                                        anchors.top: parent.top
+                                        anchors.left: parent.left
+                                        anchors.right: parent.right
+                                        anchors.margins: 2
+                                        height: parent.height - 8
+                                        radius: Kirigami.Units.cornerRadius + 2
+                                        color: tab.selected
+                                               ? Kirigami.Theme.highlightColor
+                                               : (tabMouse.containsMouse
+                                                  ? Qt.alpha(Kirigami.Theme.textColor, 0.06)
+                                                  : "transparent")
+
+                                        ColumnLayout {
+                                            anchors.centerIn: parent
+                                            spacing: Math.round(Kirigami.Units.smallSpacing / 2)
+
+                                            Item {
+                                                Layout.alignment: Qt.AlignHCenter
+                                                Layout.preferredWidth: Kirigami.Units.iconSizes.smallMedium
+                                                Layout.preferredHeight: Kirigami.Units.iconSizes.smallMedium
+
+                                                // 2×2 grid of rounded squares, like the original
+                                                // Overview tab icon (crisp in light and dark mode)
+                                                Grid {
+                                                    visible: tab.isOverview
+                                                    anchors.centerIn: parent
+                                                    rows: 2
+                                                    columns: 2
+                                                    spacing: Math.max(2, Math.round(parent.width * 0.14))
+
+                                                    Repeater {
+                                                        model: 4
+                                                        Rectangle {
+                                                            width: Math.round(Kirigami.Units.iconSizes.smallMedium * 0.36)
+                                                            height: width
+                                                            radius: Math.max(2, width * 0.3)
+                                                            color: tab.selected
+                                                                   ? Kirigami.Theme.highlightedTextColor
+                                                                   : Qt.alpha(Kirigami.Theme.textColor, 0.7)
+                                                        }
+                                                    }
+                                                }
+
+                                                ProviderIconImage {
+                                                    visible: !tab.isOverview
+                                                    anchors.fill: parent
+                                                    iconFile: tab.meta.icon
+                                                    displayContext: tab.selected
+                                                                    ? ProviderIconImage.SelectedContext
+                                                                    : ProviderIconImage.NormalContext
+                                                }
+                                            }
+
+                                            PlasmaComponents3.Label {
+                                                id: tabLabel
+                                                Layout.alignment: Qt.AlignHCenter
+                                                Layout.maximumWidth: tab.width - Kirigami.Units.smallSpacing * 2
+                                                text: tab.isOverview ? i18n("Overview") : tab.meta.name
+                                                font.pointSize: Kirigami.Theme.smallFont.pointSize * 0.95
                                                 color: tab.selected
                                                        ? Kirigami.Theme.highlightedTextColor
-                                                       : Qt.alpha(Kirigami.Theme.textColor, 0.7)
+                                                       : Qt.alpha(Kirigami.Theme.textColor, 0.75)
                                             }
                                         }
                                     }
 
-                                    ProviderIconImage {
-                                        visible: !tab.isOverview
-                                        anchors.fill: parent
-                                        iconFile: tab.meta.icon
-                                        displayContext: tab.selected
-                                                        ? ProviderIconImage.SelectedContext
-                                                        : ProviderIconImage.NormalContext
+                                    // quota indicator under the tab (hidden while selected, like the original)
+                                    UsageBar {
+                                        anchors.left: parent.left
+                                        anchors.right: parent.right
+                                        anchors.bottom: parent.bottom
+                                        anchors.leftMargin: Kirigami.Units.smallSpacing * 2
+                                        anchors.rightMargin: Kirigami.Units.smallSpacing * 2
+                                        height: 3
+                                        visible: !tab.selected && !tab.isOverview
+                                        percent: tab.remaining >= 0 ? tab.remaining : 0
+                                        fillColor: tab.meta.color
                                     }
-                                }
 
-                                PlasmaComponents3.Label {
-                                    Layout.alignment: Qt.AlignHCenter
-                                    Layout.maximumWidth: tab.width - 6
-                                    text: tab.isOverview ? i18n("Overview") : tab.meta.name
-                                    font.pointSize: Kirigami.Theme.smallFont.pointSize * 0.95
-                                    elide: Text.ElideRight
-                                    color: tab.selected
-                                           ? Kirigami.Theme.highlightedTextColor
-                                           : Qt.alpha(Kirigami.Theme.textColor, 0.75)
+                                    MouseArea {
+                                        id: tabMouse
+                                        anchors.fill: parent
+                                        hoverEnabled: true
+                                        onClicked: fullRoot.plasmoidRoot.currentTab = tab.tabId
+                                    }
                                 }
                             }
                         }
+                    }
 
-                        // quota indicator under the tab (hidden while selected, like the original)
-                        UsageBar {
-                            anchors.left: parent.left
-                            anchors.right: parent.right
-                            anchors.bottom: parent.bottom
-                            anchors.leftMargin: Kirigami.Units.smallSpacing * 2
-                            anchors.rightMargin: Kirigami.Units.smallSpacing * 2
-                            height: 3
-                            visible: !tab.selected && !tab.isOverview
-                            percent: tab.remaining >= 0 ? tab.remaining : 0
-                            fillColor: tab.meta.color
-                        }
-
-                        MouseArea {
-                            id: tabMouse
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            onClicked: fullRoot.plasmoidRoot.currentTab = tab.tabId
-                        }
+                    PlasmaComponents3.ToolButton {
+                        visible: tabStrip.overflowing
+                        enabled: !tabList.atXEnd
+                        Layout.preferredWidth: Kirigami.Units.iconSizes.smallMedium
+                        Layout.fillHeight: true
+                        icon.name: "go-next-symbolic"
+                        onClicked: tabList.scrollByPage(1)
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- size fly-out provider tabs from their complete labels instead of dividing a fixed row equally
- keep the popup compact around four initially visible tabs
- add visible previous/next controls when providers overflow while retaining wheel, touchpad, and drag navigation
- constrain adaptive popup sizing to the monitor's usable width
- automatically reveal the complete selected tab, including when switching from a panel logo
- use the exact laid-out row extent so the final provider is reachable without false trailing space
- reserve clearance for the vertical scrollbar so it cannot cover the right-navigation control
- preserve the existing selected-tab styling, provider icons, and quota underlines
- use the final shared provider-icon display contexts from #7 for selected and unselected tabs

In plain English: providers keep readable names, the arrows make hidden tabs discoverable, selecting a provider brings its whole tab into view, and the horizontal and vertical scroll controls no longer fight for the same space.

## Why

With many providers enabled, the equal-width row compresses labels and eventually icons into ellipses even when a clearer layout is possible.

![Provider tabs compressed into icons and ellipses](https://raw.githubusercontent.com/Josephur/codexbar-plasmoid/bacdd815462390d903770fb567eb32c28b166146/docs/screenshots/Need%20For%20Tab%20Spacing.png)

A first scrollable prototype also showed that hidden horizontal scrolling was difficult to discover and that Qt's virtualized `ListView` could underestimate the final extent of variable-width delegates. That allowed selected or final providers to remain partially clipped.

This implementation uses natural-width delegates inside a lightweight `Flickable` row, giving the arrows and selected-tab reveal logic an exact scroll boundary.

![Natural-width tabs with visible arrow navigation](https://raw.githubusercontent.com/Josephur/codexbar-plasmoid/fe9fa94804527905e33ab84469943144f1f83033/docs/screenshots/Tab%20Spacing%20and%20Scrolling.png)

The screenshot illustrates the natural-width layout and arrow controls. The submitted version additionally includes the subsequently tested final-edge and vertical-scrollbar clearance corrections.

## Human verification

Tested locally on Plasma 6 with 16 enabled providers:

- both overflow arrows;
- wheel and drag navigation;
- first, middle, next-to-last, and final-provider selection;
- switching providers from the panel while the fly-out remains open;
- complete selected-tab reveal;
- true final-provider reachability without trailing blank space;
- vertically scrolling Overview content without overlap between its scrollbar and the right-navigation arrow.

## Maintainer validation

Rebased onto current `main` at `484b151`, including the final KSvg provider-icon renderer from #7. The old `tint` binding was replaced with its selected/normal `displayContext` equivalent, and all trailing whitespace was removed.

- `qmllint contents/ui/*.qml`
- `xmllint --noout contents/config/main.xml contents/icons/*.svg`
- `jq empty metadata.json`
- `kpackagetool6 -t Plasma/Applet --hash "$PWD"`
- isolated `plasmawindowed` package loads with both default settings and 16 enabled providers, with no runtime QML, KSvg, type, or binding errors
- boundary simulation for first, middle, next-to-last, and final tabs, both paging directions, complete selected-tab reveal, and exact final extent
- `git diff --check`

Closes #8
