### PR TITLE
fix: decouple cost scans from quota refreshes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ a faithful re-creation of [CodexBar](https://github.com/steipete/CodexBar)
   rate windows ("Codex Spark", model-scoped weekly caps, …) with progress
   bars, reset countdowns and a pace line, Codex reset credits, cost
   (today / last 30 days from local token logs via `codexbar cost`),
-  provider status and account info.
-- **Actions:** Refresh, Usage Dashboard, Status Page, Settings, About.
+  provider status and account info. Cost scanning is disabled by default
+  because large local histories can be resource-intensive.
+- **Actions:** Refresh, explicit cost-history refresh, Usage Dashboard, Status
+  Page, Settings, About.
 - **Settings:** refresh interval, any of the 58 providers the CLI supports,
   panel percentage (session/weekly/lowest, remaining/used), plain bars,
   cost/status toggles, custom CLI path.
@@ -44,6 +46,13 @@ a faithful re-creation of [CodexBar](https://github.com/steipete/CodexBar)
 
   The CLI reads the credentials of the provider tools you already use
   (Claude Code, Codex CLI, …) — no extra login required.
+
+## Cost refresh behavior
+
+Quota refreshes never start local-history cost scans. When the optional cost
+section is enabled, automatic cost scans are serialized and run no more than
+once per provider per hour. Use **Refresh cost history** on a Codex or Claude
+provider page when an immediate scan is required.
 
 ## Install
 

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -30,7 +30,7 @@
             <default>meters</default>
         </entry>
         <entry name="showCost" type="Bool">
-            <default>true</default>
+            <default>false</default>
         </entry>
         <entry name="showStatus" type="Bool">
             <default>true</default>

--- a/contents/ui/AboutPage.qml
+++ b/contents/ui/AboutPage.qml
@@ -34,7 +34,7 @@ ColumnLayout {
             }
 
             PlasmaComponents3.Label {
-                text: i18n("Plasma port, v0.1.0 — data via codexbar CLI")
+                text: i18n("Plasma port, v0.2.2 — data via codexbar CLI")
                 opacity: 0.6
                 font: Kirigami.Theme.smallFont
             }

--- a/contents/ui/FullView.qml
+++ b/contents/ui/FullView.qml
@@ -233,6 +233,18 @@ Item {
             }
 
             MenuRow {
+                visible: fullRoot.onProviderTab
+                         && Plasmoid.configuration.showCost
+                         && Catalog.COST_PROVIDERS.indexOf(fullRoot.currentTab) >= 0
+                iconName: "view-refresh-symbolic"
+                label: fullRoot.plasmoidRoot.costRefreshInFlight === fullRoot.currentTab
+                       ? i18n("Refreshing cost history…")
+                       : i18n("Refresh cost history")
+                interactive: fullRoot.plasmoidRoot.canRefreshCost(fullRoot.currentTab)
+                onActivated: fullRoot.plasmoidRoot.refreshCost(fullRoot.currentTab, true)
+            }
+
+            MenuRow {
                 visible: fullRoot.currentTab !== "about" && fullRoot.onProviderTab
                 iconName: "view-statistics-symbolic"
                 label: i18n("Usage Dashboard")

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -115,6 +115,14 @@ KCM.SimpleKCM {
             text: i18n("Show cost section (local token logs)")
         }
 
+        QQC2.Label {
+            Layout.fillWidth: true
+            text: i18n("Cost scans can use significant disk and memory resources. Automatic scans run at most once per hour; use the separate menu action for an immediate scan.")
+            wrapMode: Text.WordWrap
+            opacity: 0.7
+            font: Kirigami.Theme.smallFont
+        }
+
         QQC2.CheckBox {
             id: showStatus
             text: i18n("Show provider status")

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -32,6 +32,12 @@ PlasmoidItem {
 
     property var pendingUsage: ({})
     property var pendingCost: ({})
+    property string costRefreshInFlight: ""
+    property string costSourceInFlight: ""
+    property var lastCostAttemptAt: ({})
+    readonly property int costAutoRefreshIntervalMs: 60 * 60 * 1000
+    readonly property int costSchedulerIntervalMs: 5 * 60 * 1000
+    readonly property bool costEnabled: Plasmoid.configuration.showCost
     // Providers whose CLI process died with SIGSEGV are skipped by automatic
     // refreshes. A manual refresh still retries after the CLI was upgraded.
     property var autoRefreshBlocked: ({})
@@ -95,6 +101,63 @@ PlasmoidItem {
         }
     }
 
+    function supportsCost(p) {
+        return Catalog.COST_PROVIDERS.indexOf(p) >= 0
+    }
+
+    function deferAutomaticCostScans() {
+        var attempts = Object.assign({}, lastCostAttemptAt)
+        var now = Date.now()
+        for (var i = 0; i < enabledProviders.length; i++) {
+            var provider = enabledProviders[i]
+            if (supportsCost(provider) && typeof attempts[provider] !== "number")
+                attempts[provider] = now
+        }
+        lastCostAttemptAt = attempts
+    }
+
+    function canRefreshCost(p) {
+        return costEnabled && supportsCost(p)
+            && enabledProviders.indexOf(p) >= 0
+            && costRefreshInFlight === ""
+    }
+
+    function refreshCost(p, force) {
+        if (!canRefreshCost(p))
+            return false
+
+        var now = Date.now()
+        var previousAttempt = lastCostAttemptAt[p]
+        if (force !== true && typeof previousAttempt === "number"
+                && now - previousAttempt < costAutoRefreshIntervalMs)
+            return false
+
+        var attempts = Object.assign({}, lastCostAttemptAt)
+        attempts[p] = now
+        lastCostAttemptAt = attempts
+
+        if (!usageData[p])
+            usageData[p] = {}
+        usageData[p].costLoading = true
+        bump()
+
+        var costCmd = cliCmd("cost --provider " + p + " --json")
+        pendingCost[costCmd] = { p: p }
+        costRefreshInFlight = p
+        costSourceInFlight = costCmd
+        executable.connectSource(costCmd)
+        return true
+    }
+
+    function refreshNextCost() {
+        if (!costEnabled || costRefreshInFlight !== "")
+            return
+        for (var i = 0; i < enabledProviders.length; i++) {
+            if (refreshCost(enabledProviders[i], false))
+                return
+        }
+    }
+
     function refreshProvider(p) {
         if (!usageData[p])
             usageData[p] = {}
@@ -106,12 +169,6 @@ PlasmoidItem {
         var cmd = cliCmd("usage --provider " + p + " --json" + (Plasmoid.configuration.showStatus ? " --status" : ""))
         pendingUsage[cmd] = { p: p, gen: gen }
         executable.connectSource(cmd)
-
-        if (Plasmoid.configuration.showCost && Catalog.COST_PROVIDERS.indexOf(p) >= 0) {
-            var costCmd = cliCmd("cost --provider " + p + " --json")
-            pendingCost[costCmd] = { p: p, gen: gen }
-            executable.connectSource(costCmd)
-        }
     }
 
     function usageErrorText(exitCode, parseFailed) {
@@ -165,20 +222,19 @@ PlasmoidItem {
         var creq = pendingCost[source]
         if (creq !== undefined) {
             delete pendingCost[source]
-            if (requestGen[creq.p] !== creq.gen)
-                return
+            if (costSourceInFlight === source) {
+                costRefreshInFlight = ""
+                costSourceInFlight = ""
+            }
             var dc = usageData[creq.p]
             if (!dc)
                 dc = usageData[creq.p] = {}
+            dc.costLoading = false
             var pc = null
             try { pc = JSON.parse((stdout || "").trim()) } catch (e2) { pc = null }
-            if (pc && pc.length > 0) {
+            if (exitCode === 0 && pc && pc.length > 0) {
                 dc.cost = pc[0]
                 dc.costUpdatedAt = Date.now()
-            } else {
-                // drop stale cost data instead of showing outdated numbers forever
-                dc.cost = null
-                dc.costUpdatedAt = 0
             }
             bump()
         }
@@ -248,8 +304,17 @@ PlasmoidItem {
         onTriggered: root.refreshAll(false)
     }
 
+    Timer {
+        id: costRefreshTimer
+        interval: root.costSchedulerIntervalMs
+        running: root.costEnabled
+        repeat: true
+        onTriggered: root.refreshNextCost()
+    }
+
     Component.onCompleted: {
         currentTab = defaultTab()
+        deferAutomaticCostScans()
         refreshAll(false)
     }
 
@@ -259,7 +324,13 @@ PlasmoidItem {
                 || enabledProviders.indexOf(currentTab) >= 0
         if (!valid)
             currentTab = defaultTab()
+        deferAutomaticCostScans()
         refreshAll(true)
+    }
+
+    onCostEnabledChanged: {
+        if (costEnabled)
+            deferAutomaticCostScans()
     }
 
     onExpandedChanged: {
@@ -272,6 +343,15 @@ PlasmoidItem {
             text: i18n("Refresh")
             icon.name: "view-refresh-symbolic"
             onTriggered: root.refreshAll(true)
+        },
+        PlasmaCore.Action {
+            text: root.costRefreshInFlight === root.currentTab
+                  ? i18n("Refreshing cost history…")
+                  : i18n("Refresh cost history")
+            icon.name: "view-refresh-symbolic"
+            visible: root.costEnabled && root.supportsCost(root.currentTab)
+            enabled: root.canRefreshCost(root.currentTab)
+            onTriggered: root.refreshCost(root.currentTab, true)
         }
     ]
 

--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
         "Id": "com.github.psimaker.codexbar",
         "License": "MIT",
         "Name": "CodexBar",
-        "Version": "0.2.1",
+        "Version": "0.2.2",
         "Website": "https://github.com/psimaker/codexbar-plasmoid"
     },
     "X-Plasma-API-Minimum-Version": "6.0"


### PR DESCRIPTION
## Summary

- remove local-history cost scans from the quota refresh path
- serialize cost scans globally and enforce a one-hour cooldown per provider
- defer the first automatic scan for one hour after startup or provider enablement
- add a separate manual **Refresh cost history** action
- disable the optional cost section by default for new installations
- retain the last successful cost snapshot when a later scan fails
- bump the plasmoid version to 0.2.2

## Root cause

`refreshProvider()` launched `codexbar cost` on every quota refresh. With a one-minute quota interval and a large local session corpus, each completed progressive scan allowed another expensive scan to start on a later tick, creating sustained disk and memory pressure.

## User impact

Quota refreshes are now lightweight. Cost scans are opt-in, never overlap, and cannot run automatically more than once per provider per hour. Users who need an immediate update can request it explicitly from a Codex or Claude provider page.

## Validation

- `qmllint` on the changed QML files
- `xmllint --noout contents/config/main.xml`
- `jq empty metadata.json`
- structural cost refresh policy checks
- `git diff --check`

Closes #10