### PR TITLE
chore: prepare 0.3.0 release

### DIFF
--- a/contents/ui/AboutPage.qml
+++ b/contents/ui/AboutPage.qml
@@ -34,7 +34,7 @@ ColumnLayout {
             }
 
             PlasmaComponents3.Label {
-                text: i18n("Plasma port, v0.2.2 — data via codexbar CLI")
+                text: i18n("Plasma port, v0.3.0 — data via codexbar CLI")
                 opacity: 0.6
                 font: Kirigami.Theme.smallFont
             }

--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
         "Id": "com.github.psimaker.codexbar",
         "License": "MIT",
         "Name": "CodexBar",
-        "Version": "0.2.2",
+        "Version": "0.3.0",
         "Website": "https://github.com/psimaker/codexbar-plasmoid"
     },
     "X-Plasma-API-Minimum-Version": "6.0"


### PR DESCRIPTION
## Summary

- bump the plasmoid package version from 0.2.2 to 0.3.0
- update the About page version
- prepare the release containing:
  - optional Claude multi-account adapter support from #3
  - Plasma theme-aware provider icons from #7
  - natural-width provider tabs and overflow navigation from #9

## Validation

- `qmllint contents/ui/*.qml`
- `xmllint --noout contents/config/main.xml contents/icons/*.svg`
- `jq empty metadata.json`
- version consistency check for metadata and About
- `kpackagetool6 -t Plasma/Applet --hash "$PWD"`
- `git diff --check`
